### PR TITLE
Input method (soft keyboard) support

### DIFF
--- a/android-activity/Cargo.toml
+++ b/android-activity/Cargo.toml
@@ -25,6 +25,7 @@ native-activity = []
 [dependencies]
 log = "0.4"
 jni-sys = "0.3"
+cesu8 = "1"
 ndk = "0.7"
 ndk-sys = "0.4"
 ndk-context = "0.1"

--- a/android-activity/game-activity-csrc/game-activity/native_app_glue/android_native_app_glue.c
+++ b/android-activity/game-activity-csrc/game-activity/native_app_glue/android_native_app_glue.c
@@ -674,6 +674,7 @@ static void onTextInputEvent(GameActivity* activity,
     pthread_mutex_lock(&android_app->mutex);
     if (!android_app->destroyed) {
         android_app->textInputState = 1;
+        notifyInput(android_app);
     }
     pthread_mutex_unlock(&android_app->mutex);
 }

--- a/android-activity/src/game_activity/input.rs
+++ b/android-activity/src/game_activity/input.rs
@@ -26,6 +26,7 @@ use crate::input::{Class, Source};
 pub enum InputEvent<'a> {
     MotionEvent(MotionEvent<'a>),
     KeyEvent(KeyEvent<'a>),
+    TextEvent(crate::input::TextInputState),
 }
 
 /// A bitfield representing the state of modifier keys during an event.

--- a/android-activity/src/input.rs
+++ b/android-activity/src/input.rs
@@ -81,3 +81,41 @@ impl From<Source> for Class {
         source.into()
     }
 }
+
+/// This struct holds a span within a region of text from `start` to `end`.
+///
+/// The `start` index may be greater than the `end` index (swapping `start` and `end` will represent the same span)
+///
+/// The lower index is inclusive and the higher index is exclusive.
+///
+/// An empty span or cursor position is specified with `start == end`.
+///
+#[derive(Debug, Clone, Copy)]
+pub struct TextSpan {
+    /// The start of the span (inclusive)
+    pub start: usize,
+
+    /// The end of the span (exclusive)
+    pub end: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct TextInputState {
+    pub text: String,
+
+    /// A selection defined on the text.
+    ///
+    /// To set the cursor position, start and end should have the same value.
+    ///
+    /// Changing the selection has no effect on the compose_region.
+    pub selection: TextSpan,
+
+    /// A composing region defined on the text.
+    ///
+    /// When being set, then if there was a composing region, the region is replaced.
+    ///
+    /// The given indices will be clamped to the `text` bounds
+    ///
+    /// If the resulting region is zero-sized, no region is marked (equivalent to passing `None`)
+    pub compose_region: Option<TextSpan>,
+}

--- a/android-activity/src/lib.rs
+++ b/android-activity/src/lib.rs
@@ -618,6 +618,16 @@ impl AndroidApp {
             .hide_soft_input(hide_implicit_only);
     }
 
+    /// Fetch the current input text state, as updated by any active IME.
+    pub fn text_input_state(&self) -> input::TextInputState {
+        self.inner.read().unwrap().text_input_state()
+    }
+
+    /// Forward the given input text `state` to any active IME.
+    pub fn set_text_input_state(&self, state: input::TextInputState) {
+        self.inner.read().unwrap().set_text_input_state(state);
+    }
+
     /// Query and process all out-standing input event
     ///
     /// `callback` should return [`InputStatus::Unhandled`] for any input events that aren't directly

--- a/android-activity/src/native_activity/input.rs
+++ b/android-activity/src/native_activity/input.rs
@@ -337,4 +337,5 @@ impl<'a> KeyEvent<'a> {
 pub enum InputEvent<'a> {
     MotionEvent(self::MotionEvent<'a>),
     KeyEvent(self::KeyEvent<'a>),
+    TextEvent(crate::input::TextInputState),
 }

--- a/android-activity/src/native_activity/mod.rs
+++ b/android-activity/src/native_activity/mod.rs
@@ -9,6 +9,7 @@ use libc::c_void;
 use log::{error, trace};
 use ndk::{asset::AssetManager, native_window::NativeWindow};
 
+use crate::input::{TextInputState, TextSpan};
 use crate::{
     util, AndroidApp, ConfigurationRef, InputStatus, MainEvent, PollEvent, Rect, WindowManagerFlags,
 };
@@ -341,6 +342,20 @@ impl AndroidAppInner {
         }
     }
 
+    // TODO: move into a trait
+    pub fn text_input_state(&self) -> TextInputState {
+        TextInputState {
+            text: String::new(),
+            selection: TextSpan { start: 0, end: 0 },
+            compose_region: None,
+        }
+    }
+
+    // TODO: move into a trait
+    pub fn set_text_input_state(&self, _state: TextInputState) {
+        // NOP: Unsupported
+    }
+
     pub fn enable_motion_axis(&self, _axis: input::Axis) {
         // NOP - The InputQueue API doesn't let us optimize which axis values are read
     }
@@ -390,6 +405,7 @@ impl AndroidAppInner {
                     input::InputEvent::KeyEvent(e) => {
                         ndk::event::InputEvent::KeyEvent(e.into_ndk_event())
                     }
+                    _ => unreachable!(),
                 };
                 queue.finish_event(ndk_event, matches!(handled, InputStatus::Handled));
             }


### PR DESCRIPTION
Add input method support based on the GameTextInput library (only supported with `game-activity` currently)

This is based on discussion for #18 and [here](https://github.com/rib/android-activity/pull/21)