### PR TITLE
native_activity: Demote spammy `info!`/`eprintln!` debug logs to `trace!`

### DIFF
--- a/android-activity/src/native_activity/glue.rs
+++ b/android-activity/src/native_activity/glue.rs
@@ -333,7 +333,7 @@ impl WaitableNativeActivityState {
             let config = super::ConfigurationRef::new(Configuration::from_ptr(
                 NonNull::new_unchecked(config),
             ));
-            eprintln!("Config: {:#?}", config);
+            log::trace!("Config: {:#?}", config);
             config
         };
 
@@ -762,9 +762,11 @@ extern "C" fn ANativeActivity_onCreate(
         });
     }
 
-    eprintln!(
+    log::trace!(
         "Creating: {:p}, saved_state = {:p}, save_state_size = {}",
-        activity, saved_state, saved_state_size
+        activity,
+        saved_state,
+        saved_state_size
     );
 
     // Conceptually we associate a glue reference with the JVM main thread, and another

--- a/android-activity/src/native_activity/mod.rs
+++ b/android-activity/src/native_activity/mod.rs
@@ -5,7 +5,7 @@ use std::ptr::NonNull;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
-use log::{error, info, trace};
+use log::{error, trace};
 
 use ndk_sys::ALooper_wake;
 use ndk_sys::{ALooper, ALooper_pollAll};
@@ -159,7 +159,7 @@ impl AndroidAppInner {
                 -1
             };
 
-            info!("Calling ALooper_pollAll, timeout = {timeout_milliseconds}");
+            trace!("Calling ALooper_pollAll, timeout = {timeout_milliseconds}");
             assert!(
                 !ndk_sys::ALooper_forThread().is_null(),
                 "Application tried to poll events from non-main thread"
@@ -170,7 +170,7 @@ impl AndroidAppInner {
                 &mut events,
                 &mut source as *mut *mut core::ffi::c_void,
             );
-            info!("pollAll id = {id}");
+            trace!("pollAll id = {id}");
             match id {
                 ndk_sys::ALOOPER_POLL_WAKE => {
                     trace!("ALooper_pollAll returned POLL_WAKE");


### PR DESCRIPTION
Ideally information - especially when spamming per `Looper` poll - used for debugging `android-activity` doesn't show to the user unless they use the `Trace` level (eventually for this specific crate/module).  This is already adhered to in most places of the code but there were a few high-volume cases still remaining.
