### PR TITLE
Release 0.4.1

### DIFF
--- a/android-activity/CHANGELOG.md
+++ b/android-activity/CHANGELOG.md
@@ -3,9 +3,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.4.1] - 2022-02-16
 ### Added
 - Added `AndroidApp::vm_as_ptr()` to expose JNI `JavaVM` pointer ([#60](https://github.com/rust-mobile/android-activity/issues/60))
 - Added `AndroidApp::activity_as_ptr()` to expose Android `Activity` JNI reference as pointer ([#60](https://github.com/rust-mobile/android-activity/issues/60))
+### Changed
+- Removed some overly-verbose logging in the `native-activity` backend ([#49](https://github.com/rust-mobile/android-activity/pull/49))
+### Removed
+- Most of the examples were moved to https://github.com/rust-mobile/rust-android-examples ([#50](https://github.com/rust-mobile/android-activity/pull/50))
 
 ## [0.4] - 2022-11-10
 ### Changed

--- a/android-activity/Cargo.toml
+++ b/android-activity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "android-activity"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 keywords = ["android", "ndk"]
 readme = "../README.md"


### PR DESCRIPTION
No big changes, but it would be good to propagate the URL changes since migrating to `rust-mobile` as well as the APIs exposing the `JavaVM` + `Activity` pointers and removal of verbose logging in the `native-activity` backend.

Cc: @MarijnS95 