### PR TITLE
Add MSRV policy to README and bump `rust_version` to 0.64, due to `ndk` -> `raw_window_handle` dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,9 @@ jobs:
           i686-linux-android
 
       - name: Install cargo-ndk
-        run: cargo install cargo-ndk
+        # We're currently sticking with cargo-ndk 2, until we bump our
+        # MSRV to 1.68+
+        run: cargo install cargo-ndk --version "^2"
 
       - name: Setup Java
         uses: actions/setup-java@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         # We need to support the same MSRV as Winit which we are currently
         # assuming will be bumped to 1.60.0 soon:
         # https://github.com/rust-windowing/winit/pull/2453
-        rust_version: [1.60.0, stable]
+        rust_version: [1.64.0, stable]
     steps:
       - uses: actions/checkout@v2
 

--- a/README.md
+++ b/README.md
@@ -147,3 +147,11 @@ Prior to working on android-activity, the existing glue crates available for bui
 [`AppCompatActivity`]: https://developer.android.com/reference/androidx/appcompat/app/AppCompatActivity
 
 
+# MSRV
+
+We aim to (at least) support stable releases of Rust from the last three months. Rust has a 6 week release cycle which means we will support the last three stable releases.
+For example, when Rust 1.69 is released we would limit our `rust_version` to 1.67.
+
+We will only bump the `rust_version` at the point where we either depend on a new features or a dependency has increased its MSRV, and we won't be greedy. In other words we will only set the MSRV to the lowest version that's _needed_.
+
+MSRV updates are not considered to be inherently semver breaking (unless a new feature is exposed in the public API) and so a `rust_version` change may happen in patch releases.

--- a/android-activity/Cargo.toml
+++ b/android-activity/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/rust-mobile/android-activity"
 documentation = "https://docs.rs/android-activity"
 description = "Glue for building Rust applications on Android with NativeActivity or GameActivity"
 license = "MIT OR Apache-2.0"
+rust_version = "0.64"
 
 [features]
 # Note: we don't enable any backend by default since features


### PR DESCRIPTION
This also updates the CI to test with `cargo-ndk` 2, which compiles with rustc 1.64 (whereas v3 requires 1.68)