### PR TITLE
Fix rust_version typo s/0.64/1.64/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # We need to support the same MSRV as Winit which we are currently
-        # assuming will be bumped to 1.60.0 soon:
-        # https://github.com/rust-windowing/winit/pull/2453
+        # See top README for MSRV policy
         rust_version: [1.64.0, stable]
     steps:
       - uses: actions/checkout@v3

--- a/android-activity/Cargo.toml
+++ b/android-activity/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/rust-mobile/android-activity"
 documentation = "https://docs.rs/android-activity"
 description = "Glue for building Rust applications on Android with NativeActivity or GameActivity"
 license = "MIT OR Apache-2.0"
-rust_version = "0.64"
+rust_version = "1.64"
 
 [features]
 # Note: we don't enable any backend by default since features


### PR DESCRIPTION
Also removes a stale comment about MSVR policy in ci.yml

This addresses a couple of things from https://github.com/rust-mobile/android-activity/pull/76

Cc: @MarijnS95 