### PR TITLE
game_activity: Fix `pointer_index()` always returning `0`

### DIFF
--- a/android-activity/src/game_activity/input.rs
+++ b/android-activity/src/game_activity/input.rs
@@ -332,7 +332,7 @@ impl<'a> MotionEvent<'a> {
     /// or [`PointerDown`](MotionAction::PointerDown).
     #[inline]
     pub fn pointer_index(&self) -> usize {
-        let action = self.action as u32 & ndk_sys::AMOTION_EVENT_ACTION_MASK;
+        let action = self.action as u32;
         let index = (action & ndk_sys::AMOTION_EVENT_ACTION_POINTER_INDEX_MASK)
             >> ndk_sys::AMOTION_EVENT_ACTION_POINTER_INDEX_SHIFT;
         index as usize


### PR DESCRIPTION
Given `AMOTION_EVENT_ACTION_MASK` is 0xff and `AMOTION_EVENT_ACTION_POINTER_INDEX_MASK` is 0xff00, this function always returns 0. Looks like ANDing with `AMOTION_EVENT_ACTION_MASK` should be removed.