### PR TITLE
Bump `bitflags` to v2

### DIFF
--- a/android-activity/Cargo.toml
+++ b/android-activity/Cargo.toml
@@ -31,7 +31,7 @@ ndk-sys = "0.4"
 ndk-context = "0.1"
 android-properties = "0.2"
 num_enum = "0.6"
-bitflags = "1.3"
+bitflags = "2.0"
 libc = "0.2"
 
 [build-dependencies]

--- a/android-activity/src/input.rs
+++ b/android-activity/src/input.rs
@@ -36,6 +36,7 @@ pub enum Source {
 }
 
 bitflags! {
+    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
     struct SourceFlags: u32 {
         const CLASS_MASK = 0x000000ff;
 

--- a/android-activity/src/lib.rs
+++ b/android-activity/src/lib.rs
@@ -275,6 +275,7 @@ pub use activity_impl::AndroidAppWaker;
 bitflags! {
     /// Flags for [`AndroidApp::set_window_flags`]
     /// as per the [android.view.WindowManager.LayoutParams Java API](https://developer.android.com/reference/android/view/WindowManager.LayoutParams)
+    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
     pub struct WindowManagerFlags: u32 {
         /// As long as this window is visible to the user, allow the lock
         /// screen to activate while the screen is on.  This can be used


### PR DESCRIPTION
Changelog: https://github.com/bitflags/bitflags/blob/2.0.0/CHANGELOG.md#200.

This is a breaking change. The API that is implemented by the macro is now different.

I was a bit liberal with deriving `std` traits on public types, which mimics the behavior of `bitflags` v1, let me know if we don't need all these traits. Potentially we could at least drop `PartialOrd` and `Ord`.

[Replaces https://github.com/zakarumych/gpu-alloc/pull/70](https://github.com/rust-mobile/android-activity/pull/83).