### PR TITLE
cargo: Fix `rust_version` -> `rust-version` property typo

### DIFF
--- a/android-activity/Cargo.toml
+++ b/android-activity/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/rust-mobile/android-activity"
 documentation = "https://docs.rs/android-activity"
 description = "Glue for building Rust applications on Android with NativeActivity or GameActivity"
 license = "MIT OR Apache-2.0"
-rust_version = "1.64"
+rust-version = "1.64"
 
 [features]
 # Note: we don't enable any backend by default since features


### PR DESCRIPTION
Cargo complains:

    warning: android-activity/Cargo.toml: unused manifest key: package.rust_version

Solve this by replacing the underscore with a hyphen.
