### PR TITLE
Add some initial notes for updating game-activity glue

### DIFF
--- a/android-activity/game-activity-csrc/patches/0001-GameActivity-PATCH-capture-KeyEvent-scanCode.patch
+++ b/android-activity/game-activity-csrc/patches/0001-GameActivity-PATCH-capture-KeyEvent-scanCode.patch
@@ -1,0 +1,57 @@
+From e27b6b5a44f531c0425deb0237826358be0613a3 Mon Sep 17 00:00:00 2001
+From: Robert Bragg <robert@sixbynine.org>
+Date: Sun, 8 May 2022 02:41:48 +0100
+Subject: [PATCH] GameActivity PATCH: capture KeyEvent scanCode
+
+---
+ game-activity/csrc/game-activity/GameActivity.cpp | 7 ++++++-
+ game-activity/csrc/game-activity/GameActivity.h   | 1 +
+ 2 files changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/game-activity/csrc/game-activity/GameActivity.cpp b/game-activity/csrc/game-activity/GameActivity.cpp
+index 2b37365..57bc4e1 100644
+--- a/game-activity/csrc/game-activity/GameActivity.cpp
++++ b/game-activity/csrc/game-activity/GameActivity.cpp
+@@ -1015,6 +1015,7 @@ static struct {
+     jmethodID getModifiers;
+     jmethodID getRepeatCount;
+     jmethodID getKeyCode;
++    jmethodID getScanCode;
+ } gKeyEventClassInfo;
+ 
+ extern "C" void GameActivityKeyEvent_fromJava(JNIEnv *env, jobject keyEvent,
+@@ -1046,6 +1047,8 @@ extern "C" void GameActivityKeyEvent_fromJava(JNIEnv *env, jobject keyEvent,
+             env->GetMethodID(keyEventClass, "getRepeatCount", "()I");
+         gKeyEventClassInfo.getKeyCode =
+             env->GetMethodID(keyEventClass, "getKeyCode", "()I");
++        gKeyEventClassInfo.getScanCode =
++            env->GetMethodID(keyEventClass, "getScanCode", "()I");
+ 
+         gKeyEventClassInfoInitialized = true;
+     }
+@@ -1070,7 +1073,9 @@ extern "C" void GameActivityKeyEvent_fromJava(JNIEnv *env, jobject keyEvent,
+         /*repeatCount=*/
+         env->CallIntMethod(keyEvent, gKeyEventClassInfo.getRepeatCount),
+         /*keyCode=*/
+-        env->CallIntMethod(keyEvent, gKeyEventClassInfo.getKeyCode)};
++        env->CallIntMethod(keyEvent, gKeyEventClassInfo.getKeyCode),
++        /*scanCode=*/
++        env->CallIntMethod(keyEvent, gKeyEventClassInfo.getScanCode)};
+ }
+ 
+ static bool onTouchEvent_native(JNIEnv *env, jobject javaGameActivity,
+diff --git a/game-activity/csrc/game-activity/GameActivity.h b/game-activity/csrc/game-activity/GameActivity.h
+index da102bc..7a5645c 100644
+--- a/game-activity/csrc/game-activity/GameActivity.h
++++ b/game-activity/csrc/game-activity/GameActivity.h
+@@ -262,6 +262,7 @@ typedef struct GameActivityKeyEvent {
+     int32_t modifiers;
+     int32_t repeatCount;
+     int32_t keyCode;
++    int32_t scanCode;
+ } GameActivityKeyEvent;
+ 
+ /**
+-- 
+2.41.0.windows.1
+

--- a/android-activity/game-activity-csrc/patches/0001-GameActivity-PATCH-compilation-fixes.patch
+++ b/android-activity/game-activity-csrc/patches/0001-GameActivity-PATCH-compilation-fixes.patch
@@ -1,0 +1,71 @@
+From 9267b60938219ec8db799d7f92555e13548055be Mon Sep 17 00:00:00 2001
+From: Robert Bragg <robert@sixbynine.org>
+Date: Sun, 8 May 2022 22:25:03 +0100
+Subject: [PATCH] GameActivity PATCH: compilation fixes
+
+Fixes some compilation bugs in the upstream AGDK glue code:
+https://issuetracker.google.com/issues/229997306
+---
+ game-activity/csrc/game-activity/GameActivity.cpp    | 10 +++++-----
+ game-activity/csrc/game-text-input/gametextinput.cpp |  2 --
+ 2 files changed, 5 insertions(+), 7 deletions(-)
+
+diff --git a/game-activity/csrc/game-activity/GameActivity.cpp b/game-activity/csrc/game-activity/GameActivity.cpp
+index 57bc4e1..a872422 100644
+--- a/game-activity/csrc/game-activity/GameActivity.cpp
++++ b/game-activity/csrc/game-activity/GameActivity.cpp
+@@ -1080,7 +1080,7 @@ extern "C" void GameActivityKeyEvent_fromJava(JNIEnv *env, jobject keyEvent,
+ 
+ static bool onTouchEvent_native(JNIEnv *env, jobject javaGameActivity,
+                                 jlong handle, jobject motionEvent) {
+-    if (handle == 0) return;
++    if (handle == 0) return false;
+     NativeCode *code = (NativeCode *)handle;
+     if (code->callbacks.onTouchEvent == nullptr) return false;
+ 
+@@ -1091,7 +1091,7 @@ static bool onTouchEvent_native(JNIEnv *env, jobject javaGameActivity,
+ 
+ static bool onKeyUp_native(JNIEnv *env, jobject javaGameActivity, jlong handle,
+                            jobject keyEvent) {
+-    if (handle == 0) return;
++    if (handle == 0) return false;
+     NativeCode *code = (NativeCode *)handle;
+     if (code->callbacks.onKeyUp == nullptr) return false;
+ 
+@@ -1102,9 +1102,9 @@ static bool onKeyUp_native(JNIEnv *env, jobject javaGameActivity, jlong handle,
+ 
+ static bool onKeyDown_native(JNIEnv *env, jobject javaGameActivity,
+                              jlong handle, jobject keyEvent) {
+-    if (handle == 0) return;
++    if (handle == 0) return false;
+     NativeCode *code = (NativeCode *)handle;
+-    if (code->callbacks.onKeyDown == nullptr) return;
++    if (code->callbacks.onKeyDown == nullptr) return false;
+ 
+     static GameActivityKeyEvent c_event;
+     GameActivityKeyEvent_fromJava(env, keyEvent, &c_event);
+@@ -1223,7 +1223,7 @@ static const char *const kWindowInsetsCompatTypePathName =
+ 
+ #define GET_FIELD_ID(var, clazz, fieldName, fieldDescriptor)  \
+     var = env->GetFieldID(clazz, fieldName, fieldDescriptor); \
+-    LOG_FATAL_IF(!var, "Unable to find field %s" fieldName);
++    LOG_FATAL_IF(!var, "Unable to find field %s", fieldName);
+ 
+ static int jniRegisterNativeMethods(JNIEnv *env, const char *className,
+                                     const JNINativeMethod *methods,
+diff --git a/game-activity/csrc/game-text-input/gametextinput.cpp b/game-activity/csrc/game-text-input/gametextinput.cpp
+index f25437a..6a39943 100755
+--- a/game-activity/csrc/game-text-input/gametextinput.cpp
++++ b/game-activity/csrc/game-text-input/gametextinput.cpp
+@@ -210,8 +210,6 @@ GameTextInput::GameTextInput(JNIEnv *env, uint32_t max_string_size)
+         env_->GetFieldID(stateJavaClass_, "composingRegionStart", "I");
+     stateClassInfo_.composingRegionEnd =
+         env_->GetFieldID(stateJavaClass_, "composingRegionEnd", "I");
+-
+-    return s_gameTextInput.get();
+ }
+ 
+ GameTextInput::~GameTextInput() {
+-- 
+2.41.0.windows.1
+

--- a/android-activity/game-activity-csrc/patches/0001-GameActivity-PATCH-enable-tracing.patch
+++ b/android-activity/game-activity-csrc/patches/0001-GameActivity-PATCH-enable-tracing.patch
@@ -1,0 +1,25 @@
+From b97adb91f9407f4f6998654b5b7dc14c334640d1 Mon Sep 17 00:00:00 2001
+From: Robert Bragg <robert@sixbynine.org>
+Date: Sun, 8 May 2022 02:40:39 +0100
+Subject: [PATCH] GameActivity PATCH: enable tracing
+
+---
+ game-activity/csrc/game-activity/GameActivity.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/game-activity/csrc/game-activity/GameActivity.cpp b/game-activity/csrc/game-activity/GameActivity.cpp
+index ca63915..2b37365 100644
+--- a/game-activity/csrc/game-activity/GameActivity.cpp
++++ b/game-activity/csrc/game-activity/GameActivity.cpp
+@@ -185,7 +185,7 @@ struct OwnedGameTextInputState {
+ #define ALOG_ASSERT(cond, ...) LOG_FATAL_IF(!(cond), ##__VA_ARGS__)
+ #endif
+ 
+-#define LOG_TRACE(...)
++#define LOG_TRACE(...) __android_log_print(ANDROID_LOG_DEBUG, LOG_TAG, __VA_ARGS__)
+ 
+ #ifndef NELEM
+ #define NELEM(x) ((int)(sizeof(x) / sizeof((x)[0])))
+-- 
+2.41.0.windows.1
+

--- a/android-activity/game-activity-csrc/patches/0001-GameActivity-PATCH-remove-unused-variable.patch
+++ b/android-activity/game-activity-csrc/patches/0001-GameActivity-PATCH-remove-unused-variable.patch
@@ -1,0 +1,24 @@
+From 73d56ede5f0e795583100d307fd64c2681538b8c Mon Sep 17 00:00:00 2001
+From: Robert Bragg <robert@sixbynine.org>
+Date: Wed, 25 May 2022 23:57:45 +0100
+Subject: [PATCH] GameActivity PATCH: remove unused variable
+
+---
+ .../csrc/game-activity/native_app_glue/android_native_app_glue.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/game-activity/csrc/game-activity/native_app_glue/android_native_app_glue.c b/game-activity/csrc/game-activity/native_app_glue/android_native_app_glue.c
+index 70d52c9..c0d6380 100644
+--- a/game-activity/csrc/game-activity/native_app_glue/android_native_app_glue.c
++++ b/game-activity/csrc/game-activity/native_app_glue/android_native_app_glue.c
+@@ -371,7 +371,6 @@ static void onSaveInstanceState(GameActivity* activity,
+     LOGV("SaveInstanceState: %p", activity);
+ 
+     struct android_app* android_app = ToApp(activity);
+-    void* savedState = NULL;
+     pthread_mutex_lock(&android_app->mutex);
+     android_app->stateSaved = 0;
+     android_app_write_cmd(android_app, APP_CMD_SAVE_STATE);
+-- 
+2.41.0.windows.1
+

--- a/android-activity/game-activity-csrc/patches/0001-GameActivity-PATCH-support-capturing-historic-pointe.patch
+++ b/android-activity/game-activity-csrc/patches/0001-GameActivity-PATCH-support-capturing-historic-pointe.patch
@@ -1,0 +1,342 @@
+From c36efc7f6bd4a6202b8ba249b83c3251f501bcb6 Mon Sep 17 00:00:00 2001
+From: Robert Bragg <robert@sixbynine.org>
+Date: Thu, 12 May 2022 02:27:01 +0100
+Subject: [PATCH] GameActivity PATCH: support capturing historic pointer
+ samples
+
+---
+ .../csrc/game-activity/GameActivity.cpp       | 88 ++++++++++++++++++-
+ .../csrc/game-activity/GameActivity.h         | 57 +++++++++++-
+ .../native_app_glue/android_native_app_glue.c | 18 +++-
+ .../native_app_glue/android_native_app_glue.h | 28 ++++++
+ 4 files changed, 182 insertions(+), 9 deletions(-)
+
+diff --git a/game-activity/csrc/game-activity/GameActivity.cpp b/game-activity/csrc/game-activity/GameActivity.cpp
+index d240f18..c9081d2 100644
+--- a/game-activity/csrc/game-activity/GameActivity.cpp
++++ b/game-activity/csrc/game-activity/GameActivity.cpp
+@@ -840,6 +840,27 @@ extern "C" void GameActivityPointerAxes_disableAxis(int32_t axis) {
+     enabledAxes[axis] = false;
+ }
+ 
++static bool enabledHistoricalAxes[GAME_ACTIVITY_POINTER_INFO_AXIS_COUNT] = {
++    // Disable all axes by default (they can be enabled using
++    // `GameActivityPointerAxes_enableHistoricalAxis`).
++    false};
++
++extern "C" void GameActivityHistoricalPointerAxes_enableAxis(int32_t axis) {
++    if (axis < 0 || axis >= GAME_ACTIVITY_POINTER_INFO_AXIS_COUNT) {
++        return;
++    }
++
++    enabledHistoricalAxes[axis] = true;
++}
++
++extern "C" void GameActivityHistoricalPointerAxes_disableAxis(int32_t axis) {
++    if (axis < 0 || axis >= GAME_ACTIVITY_POINTER_INFO_AXIS_COUNT) {
++        return;
++    }
++
++    enabledHistoricalAxes[axis] = false;
++}
++
+ extern "C" void GameActivity_setImeEditorInfo(GameActivity *activity,
+                                               int inputType, int actionId,
+                                               int imeOptions) {
+@@ -874,10 +895,15 @@ static struct {
+     jmethodID getXPrecision;
+     jmethodID getYPrecision;
+     jmethodID getAxisValue;
++
++    jmethodID getHistorySize;
++    jmethodID getHistoricalEventTime;
++    jmethodID getHistoricalAxisValue;
+ } gMotionEventClassInfo;
+ 
+-extern "C" void GameActivityMotionEvent_fromJava(
+-    JNIEnv *env, jobject motionEvent, GameActivityMotionEvent *out_event) {
++extern "C" int GameActivityMotionEvent_fromJava(
++    JNIEnv *env, jobject motionEvent, GameActivityMotionEvent *out_event,
++    GameActivityHistoricalPointerAxes *out_historical) {
+     static bool gMotionEventClassInfoInitialized = false;
+     if (!gMotionEventClassInfoInitialized) {
+         int sdkVersion = GetSystemPropAsInt("ro.build.version.sdk");
+@@ -928,9 +954,44 @@ extern "C" void GameActivityMotionEvent_fromJava(
+         gMotionEventClassInfo.getAxisValue =
+             env->GetMethodID(motionEventClass, "getAxisValue", "(II)F");
+ 
++        gMotionEventClassInfo.getHistorySize =
++            env->GetMethodID(motionEventClass, "getHistorySize", "()I");
++        gMotionEventClassInfo.getHistoricalEventTime =
++            env->GetMethodID(motionEventClass, "getHistoricalEventTime", "(I)J");
++        gMotionEventClassInfo.getHistoricalAxisValue =
++            env->GetMethodID(motionEventClass, "getHistoricalAxisValue", "(III)F");
++
+         gMotionEventClassInfoInitialized = true;
+     }
+ 
++    int historySize =
++        env->CallIntMethod(motionEvent, gMotionEventClassInfo.getHistorySize);
++    historySize =
++        std::min(historySize, GAMEACTIVITY_MAX_NUM_HISTORICAL_IN_MOTION_EVENT);
++
++    int localEnabledHistoricalAxis[GAME_ACTIVITY_POINTER_INFO_AXIS_COUNT];
++    int enabledHistoricalAxisCount = 0;
++
++    for (int axisIndex = 0;
++         axisIndex < GAME_ACTIVITY_POINTER_INFO_AXIS_COUNT;
++         ++axisIndex) {
++        if (enabledHistoricalAxes[axisIndex]) {
++            localEnabledHistoricalAxis[enabledHistoricalAxisCount++] = axisIndex;
++        }
++    }
++    out_event->historicalCount = enabledHistoricalAxisCount == 0 ? 0 : historySize;
++    out_event->historicalStart = 0; // Free for caller to use
++
++    // The historical event times aren't unique per-pointer but for simplicity
++    // we output a per-pointer event time, copied from here...
++    int64_t historicalEventTimes[GAMEACTIVITY_MAX_NUM_HISTORICAL_IN_MOTION_EVENT];
++    for (int histIndex = 0; histIndex < historySize; ++histIndex) {
++        historicalEventTimes[histIndex] =
++            env->CallLongMethod(motionEvent,
++                gMotionEventClassInfo.getHistoricalEventTime) *
++                1000000;
++    }
++
+     int pointerCount =
+         env->CallIntMethod(motionEvent, gMotionEventClassInfo.getPointerCount);
+     pointerCount =
+@@ -960,6 +1021,20 @@ extern "C" void GameActivityMotionEvent_fromJava(
+                                          axisIndex, i);
+             }
+         }
++
++        if (enabledHistoricalAxisCount > 0) {
++            for (int histIndex = 0; histIndex < historySize; ++histIndex) {
++                int pointerHistIndex = historySize * i;
++                out_historical[pointerHistIndex].eventTime = historicalEventTimes[histIndex];
++                for (int c = 0; c < enabledHistoricalAxisCount; ++c) {
++                    int axisIndex = localEnabledHistoricalAxis[c];
++                    out_historical[pointerHistIndex].axisValues[axisIndex] =
++                        env->CallFloatMethod(motionEvent,
++                                             gMotionEventClassInfo.getHistoricalAxisValue,
++                                             axisIndex, i, histIndex);
++                }
++            }
++        }
+     }
+ 
+     out_event->deviceId =
+@@ -999,6 +1074,8 @@ extern "C" void GameActivityMotionEvent_fromJava(
+         env->CallFloatMethod(motionEvent, gMotionEventClassInfo.getXPrecision);
+     out_event->precisionY =
+         env->CallFloatMethod(motionEvent, gMotionEventClassInfo.getYPrecision);
++
++    return out_event->pointerCount * out_event->historicalCount;
+ }
+ 
+ static struct {
+@@ -1085,8 +1162,11 @@ static bool onTouchEvent_native(JNIEnv *env, jobject javaGameActivity,
+     if (code->callbacks.onTouchEvent == nullptr) return false;
+ 
+     static GameActivityMotionEvent c_event;
+-    GameActivityMotionEvent_fromJava(env, motionEvent, &c_event);
+-    return code->callbacks.onTouchEvent(code, &c_event);
++    // Note the actual data is written contiguously as numPointers x historySize
++    // entries.
++    static GameActivityHistoricalPointerAxes historical[GAMEACTIVITY_MAX_NUM_POINTERS_IN_MOTION_EVENT * GAMEACTIVITY_MAX_NUM_HISTORICAL_IN_MOTION_EVENT];
++    int historicalLen = GameActivityMotionEvent_fromJava(env, motionEvent, &c_event, historical);
++    return code->callbacks.onTouchEvent(code, &c_event, historical, historicalLen);
+ }
+ 
+ static bool onKeyUp_native(JNIEnv *env, jobject javaGameActivity, jlong handle,
+diff --git a/game-activity/csrc/game-activity/GameActivity.h b/game-activity/csrc/game-activity/GameActivity.h
+index 7a5645c..e0c48e1 100644
+--- a/game-activity/csrc/game-activity/GameActivity.h
++++ b/game-activity/csrc/game-activity/GameActivity.h
+@@ -142,6 +142,11 @@ typedef struct GameActivityPointerAxes {
+     float rawY;
+ } GameActivityPointerAxes;
+ 
++typedef struct GameActivityHistoricalPointerAxes {
++    int64_t eventTime;
++    float axisValues[GAME_ACTIVITY_POINTER_INFO_AXIS_COUNT];
++} GameActivityHistoricalPointerAxes;
++
+ /** \brief Get the current X coordinate of the pointer. */
+ inline float GameActivityPointerAxes_getX(
+     const GameActivityPointerAxes* pointerInfo) {
+@@ -177,6 +182,26 @@ void GameActivityPointerAxes_enableAxis(int32_t axis);
+  */
+ void GameActivityPointerAxes_disableAxis(int32_t axis);
+ 
++/**
++ * \brief Enable the specified axis, so that its value is reported in the
++ * GameActivityHistoricalPointerAxes structures associated with a motion event.
++ *
++ * You must enable any axis that you want to read (no axes are enabled by
++ * default).
++ *
++ * If the axis index is out of range, nothing is done.
++ */
++void GameActivityHistoricalPointerAxes_enableAxis(int32_t axis);
++
++/**
++ * \brief Disable the specified axis. Its value won't be reported in the
++ * GameActivityHistoricalPointerAxes structures associated with motion events
++ * anymore.
++ *
++ * If the axis index is out of range, nothing is done.
++ */
++void GameActivityHistoricalPointerAxes_disableAxis(int32_t axis);
++
+ /**
+  * \brief Get the value of the requested axis.
+  *
+@@ -212,6 +237,16 @@ inline float GameActivityPointerAxes_getAxisValue(
+ #define GAMEACTIVITY_MAX_NUM_POINTERS_IN_MOTION_EVENT 8
+ #endif
+ 
++/**
++ * The maximum number of historic samples associated with a single motion event.
++ */
++#if (defined GAMEACTIVITY_MAX_NUM_HISTORICAL_IN_MOTION_EVENT_OVERRIDE)
++#define GAMEACTIVITY_MAX_NUM_HISTORICAL_IN_MOTION_EVENT \
++    GAMEACTIVITY_MAX_NUM_HISTORICAL_IN_MOTION_EVENT_OVERRIDE
++#else
++#define GAMEACTIVITY_MAX_NUM_HISTORICAL_IN_MOTION_EVENT 8
++#endif
++
+ /**
+  * \brief Describe a motion event that happened on the GameActivity SurfaceView.
+  *
+@@ -240,6 +275,13 @@ typedef struct GameActivityMotionEvent {
+ 
+     float precisionX;
+     float precisionY;
++
++    int16_t historicalStart;
++
++    // Note the actual buffer of historical data has a length of
++    // pointerCount * historicalCount, since the historical axis
++    // data is per-pointer.
++    int16_t historicalCount;
+ } GameActivityMotionEvent;
+ 
+ /**
+@@ -381,7 +423,9 @@ typedef struct GameActivityCallbacks {
+      * only valid during the callback.
+      */
+     bool (*onTouchEvent)(GameActivity* activity,
+-                         const GameActivityMotionEvent* event);
++                         const GameActivityMotionEvent* event,
++                         const GameActivityHistoricalPointerAxes* historical,
++                         int historicalLen);
+ 
+     /**
+      * Callback called for every key down event on the GameActivity SurfaceView.
+@@ -419,11 +463,16 @@ typedef struct GameActivityCallbacks {
+  * This is done automatically by the GameActivity: see `onTouchEvent` to set
+  * a callback to consume the received events.
+  * This function can be used if you re-implement events handling in your own
+- * activity.
++ * activity. On return, the out_event->historicalStart will be zero, and should
++ * be updated to index into whatever buffer out_historical is copied.
++ * On return the length of out_historical is
++ * (out_event->pointerCount x out_event->historicalCount) and is in a
++ * pointer-major order (i.e. all axis for a pointer are contiguous)
+  * Ownership of out_event is maintained by the caller.
+  */
+-void GameActivityMotionEvent_fromJava(JNIEnv* env, jobject motionEvent,
+-                                      GameActivityMotionEvent* out_event);
++int GameActivityMotionEvent_fromJava(JNIEnv* env, jobject motionEvent,
++                                     GameActivityMotionEvent* out_event,
++                                     GameActivityHistoricalPointerAxes *out_historical);
+ 
+ /**
+  * \brief Convert a Java `KeyEvent` to a `GameActivityKeyEvent`.
+diff --git a/game-activity/csrc/game-activity/native_app_glue/android_native_app_glue.c b/game-activity/csrc/game-activity/native_app_glue/android_native_app_glue.c
+index 7ae073d..ea4de04 100644
+--- a/game-activity/csrc/game-activity/native_app_glue/android_native_app_glue.c
++++ b/game-activity/csrc/game-activity/native_app_glue/android_native_app_glue.c
+@@ -441,7 +441,9 @@ void android_app_set_motion_event_filter(struct android_app* app,
+ }
+ 
+ static bool onTouchEvent(GameActivity* activity,
+-                         const GameActivityMotionEvent* event) {
++                         const GameActivityMotionEvent* event,
++                         const GameActivityHistoricalPointerAxes* historical,
++                         int historicalLen) {
+     struct android_app* android_app = ToApp(activity);
+     pthread_mutex_lock(&android_app->mutex);
+ 
+@@ -461,6 +463,20 @@ static bool onTouchEvent(GameActivity* activity,
+         memcpy(&inputBuffer->motionEvents[new_ix], event,
+                sizeof(GameActivityMotionEvent));
+         ++inputBuffer->motionEventsCount;
++
++        if (inputBuffer->historicalSamplesCount + historicalLen <=
++            NATIVE_APP_GLUE_MAX_HISTORICAL_POINTER_SAMPLES) {
++
++            int start_ix = inputBuffer->historicalSamplesCount;
++            memcpy(&inputBuffer->historicalAxisSamples[start_ix], historical,
++                    sizeof(historical[0]) * historicalLen);
++            inputBuffer->historicalSamplesCount += event->historicalCount;
++
++            inputBuffer->motionEvents[new_ix].historicalStart = start_ix;
++            inputBuffer->motionEvents[new_ix].historicalCount = historicalLen;
++        } else {
++            inputBuffer->motionEvents[new_ix].historicalCount = 0;
++        }
+     }
+     pthread_mutex_unlock(&android_app->mutex);
+     return true;
+diff --git a/game-activity/csrc/game-activity/native_app_glue/android_native_app_glue.h b/game-activity/csrc/game-activity/native_app_glue/android_native_app_glue.h
+index 4f19c8d..1e678b5 100644
+--- a/game-activity/csrc/game-activity/native_app_glue/android_native_app_glue.h
++++ b/game-activity/csrc/game-activity/native_app_glue/android_native_app_glue.h
+@@ -37,6 +37,13 @@
+ #define NATIVE_APP_GLUE_MAX_NUM_MOTION_EVENTS 16
+ #endif
+ 
++#if (defined NATIVE_APP_GLUE_MAX_HISTORICAL_POINTER_SAMPLES_OVERRIDE)
++#define NATIVE_APP_GLUE_MAX_HISTORICAL_POINTER_SAMPLES \
++    NATIVE_APP_GLUE_MAX_HISTORICAL_POINTER_SAMPLES_OVERRIDE
++#else
++#define NATIVE_APP_GLUE_MAX_HISTORICAL_POINTER_SAMPLES 64
++#endif
++
+ #if (defined NATIVE_APP_GLUE_MAX_NUM_KEY_EVENTS_OVERRIDE)
+ #define NATIVE_APP_GLUE_MAX_NUM_KEY_EVENTS \
+     NATIVE_APP_GLUE_MAX_NUM_KEY_EVENTS_OVERRIDE
+@@ -129,6 +136,27 @@ struct android_input_buffer {
+      */
+     uint64_t motionEventsCount;
+ 
++    /**
++     * Pointer to a read-only array of pointers to GameActivityHistoricalPointerAxes.
++     *
++     * Only the first historicalSamplesCount samples are valid.
++     * Refer to event->historicalStart, event->pointerCount and event->historicalCount
++     * to access the specific samples that relate to an event.
++     *
++     * Each slice of samples for one event has a length of
++     * (event->pointerCount and event->historicalCount) and is in pointer-major
++     * order so the historic samples for each pointer are contiguous.
++     * E.g. you would access historic sample index 3 for pointer 2 of an event with:
++     *
++     *   historicalAxisSamples[event->historicalStart + (event->historicalCount * 2) + 3];
++     */
++    GameActivityHistoricalPointerAxes historicalAxisSamples[NATIVE_APP_GLUE_MAX_HISTORICAL_POINTER_SAMPLES];
++
++    /**
++     * The number of valid historical samples in `historicalAxisSamples`.
++     */
++    uint64_t historicalSamplesCount;
++
+     /**
+      * Pointer to a read-only array of pointers to GameActivityKeyEvent.
+      * Only the first keyEventsCount events are valid.
+-- 
+2.41.0.windows.1
+

--- a/android-activity/game-activity-csrc/patches/0001-Supports-InputAvailable-events-with-GameActivity.patch
+++ b/android-activity/game-activity-csrc/patches/0001-Supports-InputAvailable-events-with-GameActivity.patch
@@ -1,0 +1,424 @@
+From 3d1b1c5cb9ccfb47d8a067b78bea45c4b72e2033 Mon Sep 17 00:00:00 2001
+From: Robert Bragg <robert@sixbynine.org>
+Date: Sat, 13 Aug 2022 05:42:37 +0100
+Subject: [PATCH] Supports InputAvailable events with GameActivity
+
+This makes a small change to the C glue code for GameActivity to send
+looper wake ups when new input is received (only sending a single wake
+up, until the application next handles input).
+
+When a wake up is received and we recognise that new input is available
+then an `InputAvailable` event is sent to the application - consistent
+with how NativeActivity can deliver `InputAvailable` events.
+
+This addresses a significant feature disparity between GameActivity and
+NativeActivity that meant GameActivity was not practically usable for
+GUI applications that wouldn't want to render continuously like a game.
+
+Addresses #4
+---
+ .../native_app_glue/android_native_app_glue.c | 33 +++++++++++++++++++
+ .../native_app_glue/android_native_app_glue.h | 24 ++++++++++++++
+ .../src/game_activity/ffi_aarch64.rs          | 30 ++++++++++++++++-
+ android-activity/src/game_activity/ffi_arm.rs | 28 ++++++++++++++++
+ .../src/game_activity/ffi_i686.rs             | 30 ++++++++++++++++-
+ .../src/game_activity/ffi_x86_64.rs           | 30 ++++++++++++++++-
+ android-activity/src/game_activity/mod.rs     |  6 ++++
+ examples/agdk-mainloop/.idea/gradle.xml       |  1 -
+ examples/agdk-mainloop/src/lib.rs             |  5 ++-
+ 9 files changed, 182 insertions(+), 5 deletions(-)
+
+diff --git a/android-activity/game-activity-csrc/game-activity/native_app_glue/android_native_app_glue.c b/android-activity/game-activity-csrc/game-activity/native_app_glue/android_native_app_glue.c
+index c0d6380..5fd3eb8 100644
+--- a/android-activity/game-activity-csrc/game-activity/native_app_glue/android_native_app_glue.c
++++ b/android-activity/game-activity-csrc/game-activity/native_app_glue/android_native_app_glue.c
+@@ -449,6 +449,31 @@ void android_app_set_motion_event_filter(struct android_app* app,
+     pthread_mutex_unlock(&app->mutex);
+ }
+ 
++bool android_app_input_available_wake_up(struct android_app* app) {
++    pthread_mutex_lock(&app->mutex);
++    // TODO: use atomic ops for this
++    bool available = app->inputAvailableWakeUp;
++    app->inputAvailableWakeUp = false;
++    pthread_mutex_unlock(&app->mutex);
++    return available;
++}
++
++// NB: should be called with the android_app->mutex held already
++static void notifyInput(struct android_app* android_app) {
++    // Don't spam the mainloop with wake ups if we've already sent one
++    if (android_app->inputSwapPending) {
++        return;
++    }
++
++    if (android_app->looper != NULL) {
++        LOGV("Input Notify: %p", android_app);
++        // for the app thread to know why it received the wake() up
++        android_app->inputAvailableWakeUp = true;
++        android_app->inputSwapPending = true;
++        ALooper_wake(android_app->looper);
++    }
++}
++
+ static bool onTouchEvent(GameActivity* activity,
+                          const GameActivityMotionEvent* event,
+                          const GameActivityHistoricalPointerAxes* historical,
+@@ -486,12 +511,15 @@ static bool onTouchEvent(GameActivity* activity,
+         } else {
+             inputBuffer->motionEvents[new_ix].historicalCount = 0;
+         }
++
++        notifyInput(android_app);
+     } else {
+         LOGW_ONCE("Motion event will be dropped because the number of unconsumed motion"
+              " events exceeded NATIVE_APP_GLUE_MAX_NUM_MOTION_EVENTS (%d). Consider setting"
+              " NATIVE_APP_GLUE_MAX_NUM_MOTION_EVENTS_OVERRIDE to a larger value",
+              NATIVE_APP_GLUE_MAX_NUM_MOTION_EVENTS);
+     }
++
+     pthread_mutex_unlock(&android_app->mutex);
+     return true;
+ }
+@@ -512,6 +540,9 @@ struct android_input_buffer* android_app_swap_input_buffers(
+             NATIVE_APP_GLUE_MAX_INPUT_BUFFERS;
+     }
+ 
++    android_app->inputSwapPending = false;
++    android_app->inputAvailableWakeUp = false;
++
+     pthread_mutex_unlock(&android_app->mutex);
+ 
+     return inputBuffer;
+@@ -547,6 +578,8 @@ static bool onKey(GameActivity* activity, const GameActivityKeyEvent* event) {
+         memcpy(&inputBuffer->keyEvents[new_ix], event,
+                sizeof(GameActivityKeyEvent));
+         ++inputBuffer->keyEventsCount;
++
++        notifyInput(android_app);
+     } else {
+         LOGW_ONCE("Key event will be dropped because the number of unconsumed key events exceeded"
+              " NATIVE_APP_GLUE_MAX_NUM_KEY_EVENTS (%d). Consider setting"
+diff --git a/android-activity/game-activity-csrc/game-activity/native_app_glue/android_native_app_glue.h b/android-activity/game-activity-csrc/game-activity/native_app_glue/android_native_app_glue.h
+index 1e678b5..96968e3 100644
+--- a/android-activity/game-activity-csrc/game-activity/native_app_glue/android_native_app_glue.h
++++ b/android-activity/game-activity-csrc/game-activity/native_app_glue/android_native_app_glue.h
+@@ -295,6 +295,26 @@ struct android_app {
+     android_key_event_filter keyEventFilter;
+     android_motion_event_filter motionEventFilter;
+ 
++    // When new input is received we set both of these flags and use the looper to
++    // wake up the application mainloop.
++    //
++    // To avoid spamming the mainloop with wake ups from lots of input though we
++    // don't sent a wake up if the inputSwapPending flag is already set. (i.e.
++    // we already expect input to be processed in a finite amount of time due to
++    // our previous wake up)
++    //
++    // When a wake up is received then we will check this flag (clearing it
++    // at the same time). If it was set then an InputAvailable event is sent to
++    // the application - which should lead to all input being processed within
++    // a finite amount of time.
++    //
++    // The next time android_app_swap_input_buffers is called, both flags will be
++    // cleared.
++    //
++    // NB: both of these should only be read with the app mutex held
++    bool inputAvailableWakeUp;
++    bool inputSwapPending;
++
+     /** @endcond */
+ };
+ 
+@@ -507,6 +527,10 @@ void android_app_set_key_event_filter(struct android_app* app,
+ void android_app_set_motion_event_filter(struct android_app* app,
+                                          android_motion_event_filter filter);
+ 
++/**
++ * Determines if a looper wake up was due to new input becoming available
++ */
++bool android_app_input_available_wake_up(struct android_app* app);
+ 
+ void GameActivity_onCreate_C(GameActivity* activity, void* savedState,
+                             size_t savedStateSize);
+diff --git a/android-activity/src/game_activity/ffi_aarch64.rs b/android-activity/src/game_activity/ffi_aarch64.rs
+index 6873c58..d9ebe3d 100644
+--- a/android-activity/src/game_activity/ffi_aarch64.rs
++++ b/android-activity/src/game_activity/ffi_aarch64.rs
+@@ -8437,12 +8437,14 @@ pub struct android_app {
+     pub pendingContentRect: ARect,
+     pub keyEventFilter: android_key_event_filter,
+     pub motionEventFilter: android_motion_event_filter,
++    pub inputAvailableWakeUp: bool,
++    pub inputSwapPending: bool,
+ }
+ #[test]
+ fn bindgen_test_layout_android_app() {
+     assert_eq!(
+         ::std::mem::size_of::<android_app>(),
+-        80904usize,
++        80912usize,
+         concat!("Size of: ", stringify!(android_app))
+     );
+     assert_eq!(
+@@ -8730,6 +8732,28 @@ fn bindgen_test_layout_android_app() {
+             stringify!(motionEventFilter)
+         )
+     );
++    assert_eq!(
++        unsafe {
++            &(*(::std::ptr::null::<android_app>())).inputAvailableWakeUp as *const _ as usize
++        },
++        80904usize,
++        concat!(
++            "Offset of field: ",
++            stringify!(android_app),
++            "::",
++            stringify!(inputAvailableWakeUp)
++        )
++    );
++    assert_eq!(
++        unsafe { &(*(::std::ptr::null::<android_app>())).inputSwapPending as *const _ as usize },
++        80905usize,
++        concat!(
++            "Offset of field: ",
++            stringify!(android_app),
++            "::",
++            stringify!(inputSwapPending)
++        )
++    );
+ }
+ #[doc = " Looper data ID of commands coming from the app's main thread, which"]
+ #[doc = " is returned as an identifier from ALooper_pollOnce().  The data for this"]
+@@ -8869,4 +8893,8 @@ extern "C" {
+         filter: android_motion_event_filter,
+     );
+ }
++extern "C" {
++    #[doc = " Determines if a looper wake up was due to new input becoming available"]
++    pub fn android_app_input_available_wake_up(app: *mut android_app) -> bool;
++}
+ pub type __uint128_t = u128;
+diff --git a/android-activity/src/game_activity/ffi_arm.rs b/android-activity/src/game_activity/ffi_arm.rs
+index c519f13..73b02a4 100644
+--- a/android-activity/src/game_activity/ffi_arm.rs
++++ b/android-activity/src/game_activity/ffi_arm.rs
+@@ -8906,6 +8906,8 @@ pub struct android_app {
+     pub pendingContentRect: ARect,
+     pub keyEventFilter: android_key_event_filter,
+     pub motionEventFilter: android_motion_event_filter,
++    pub inputAvailableWakeUp: bool,
++    pub inputSwapPending: bool,
+ }
+ #[test]
+ fn bindgen_test_layout_android_app() {
+@@ -9199,6 +9201,28 @@ fn bindgen_test_layout_android_app() {
+             stringify!(motionEventFilter)
+         )
+     );
++    assert_eq!(
++        unsafe {
++            &(*(::std::ptr::null::<android_app>())).inputAvailableWakeUp as *const _ as usize
++        },
++        80764usize,
++        concat!(
++            "Offset of field: ",
++            stringify!(android_app),
++            "::",
++            stringify!(inputAvailableWakeUp)
++        )
++    );
++    assert_eq!(
++        unsafe { &(*(::std::ptr::null::<android_app>())).inputSwapPending as *const _ as usize },
++        80765usize,
++        concat!(
++            "Offset of field: ",
++            stringify!(android_app),
++            "::",
++            stringify!(inputSwapPending)
++        )
++    );
+ }
+ #[doc = " Looper data ID of commands coming from the app's main thread, which"]
+ #[doc = " is returned as an identifier from ALooper_pollOnce().  The data for this"]
+@@ -9338,3 +9362,7 @@ extern "C" {
+         filter: android_motion_event_filter,
+     );
+ }
++extern "C" {
++    #[doc = " Determines if a looper wake up was due to new input becoming available"]
++    pub fn android_app_input_available_wake_up(app: *mut android_app) -> bool;
++}
+diff --git a/android-activity/src/game_activity/ffi_i686.rs b/android-activity/src/game_activity/ffi_i686.rs
+index 52b8174..4fc5a56 100644
+--- a/android-activity/src/game_activity/ffi_i686.rs
++++ b/android-activity/src/game_activity/ffi_i686.rs
+@@ -10651,12 +10651,14 @@ pub struct android_app {
+     pub pendingContentRect: ARect,
+     pub keyEventFilter: android_key_event_filter,
+     pub motionEventFilter: android_motion_event_filter,
++    pub inputAvailableWakeUp: bool,
++    pub inputSwapPending: bool,
+ }
+ #[test]
+ fn bindgen_test_layout_android_app() {
+     assert_eq!(
+         ::std::mem::size_of::<android_app>(),
+-        80604usize,
++        80608usize,
+         concat!("Size of: ", stringify!(android_app))
+     );
+     assert_eq!(
+@@ -10944,6 +10946,28 @@ fn bindgen_test_layout_android_app() {
+             stringify!(motionEventFilter)
+         )
+     );
++    assert_eq!(
++        unsafe {
++            &(*(::std::ptr::null::<android_app>())).inputAvailableWakeUp as *const _ as usize
++        },
++        80604usize,
++        concat!(
++            "Offset of field: ",
++            stringify!(android_app),
++            "::",
++            stringify!(inputAvailableWakeUp)
++        )
++    );
++    assert_eq!(
++        unsafe { &(*(::std::ptr::null::<android_app>())).inputSwapPending as *const _ as usize },
++        80605usize,
++        concat!(
++            "Offset of field: ",
++            stringify!(android_app),
++            "::",
++            stringify!(inputSwapPending)
++        )
++    );
+ }
+ #[doc = " Looper data ID of commands coming from the app's main thread, which"]
+ #[doc = " is returned as an identifier from ALooper_pollOnce().  The data for this"]
+@@ -11083,4 +11107,8 @@ extern "C" {
+         filter: android_motion_event_filter,
+     );
+ }
++extern "C" {
++    #[doc = " Determines if a looper wake up was due to new input becoming available"]
++    pub fn android_app_input_available_wake_up(app: *mut android_app) -> bool;
++}
+ pub type __builtin_va_list = *mut ::std::os::raw::c_char;
+diff --git a/android-activity/src/game_activity/ffi_x86_64.rs b/android-activity/src/game_activity/ffi_x86_64.rs
+index 03485a7..e5a2b88 100644
+--- a/android-activity/src/game_activity/ffi_x86_64.rs
++++ b/android-activity/src/game_activity/ffi_x86_64.rs
+@@ -10680,12 +10680,14 @@ pub struct android_app {
+     pub pendingContentRect: ARect,
+     pub keyEventFilter: android_key_event_filter,
+     pub motionEventFilter: android_motion_event_filter,
++    pub inputAvailableWakeUp: bool,
++    pub inputSwapPending: bool,
+ }
+ #[test]
+ fn bindgen_test_layout_android_app() {
+     assert_eq!(
+         ::std::mem::size_of::<android_app>(),
+-        80904usize,
++        80912usize,
+         concat!("Size of: ", stringify!(android_app))
+     );
+     assert_eq!(
+@@ -10973,6 +10975,28 @@ fn bindgen_test_layout_android_app() {
+             stringify!(motionEventFilter)
+         )
+     );
++    assert_eq!(
++        unsafe {
++            &(*(::std::ptr::null::<android_app>())).inputAvailableWakeUp as *const _ as usize
++        },
++        80904usize,
++        concat!(
++            "Offset of field: ",
++            stringify!(android_app),
++            "::",
++            stringify!(inputAvailableWakeUp)
++        )
++    );
++    assert_eq!(
++        unsafe { &(*(::std::ptr::null::<android_app>())).inputSwapPending as *const _ as usize },
++        80905usize,
++        concat!(
++            "Offset of field: ",
++            stringify!(android_app),
++            "::",
++            stringify!(inputSwapPending)
++        )
++    );
+ }
+ #[doc = " Looper data ID of commands coming from the app's main thread, which"]
+ #[doc = " is returned as an identifier from ALooper_pollOnce().  The data for this"]
+@@ -11112,6 +11136,10 @@ extern "C" {
+         filter: android_motion_event_filter,
+     );
+ }
++extern "C" {
++    #[doc = " Determines if a looper wake up was due to new input becoming available"]
++    pub fn android_app_input_available_wake_up(app: *mut android_app) -> bool;
++}
+ pub type __builtin_va_list = [__va_list_tag; 1usize];
+ #[repr(C)]
+ #[derive(Debug, Copy, Clone)]
+diff --git a/android-activity/src/game_activity/mod.rs b/android-activity/src/game_activity/mod.rs
+index c395d61..2b66977 100644
+--- a/android-activity/src/game_activity/mod.rs
++++ b/android-activity/src/game_activity/mod.rs
+@@ -180,6 +180,12 @@ impl AndroidAppInner {
+             match id {
+                 ffi::ALOOPER_POLL_WAKE => {
+                     trace!("ALooper_pollAll returned POLL_WAKE");
++
++                    if ffi::android_app_input_available_wake_up(app_ptr.as_ptr()) {
++                        log::debug!("Notifying Input Available");
++                        callback(PollEvent::Main(MainEvent::InputAvailable));
++                    }
++
+                     callback(PollEvent::Wake);
+                 }
+                 ffi::ALOOPER_POLL_CALLBACK => {
+diff --git a/examples/agdk-mainloop/.idea/gradle.xml b/examples/agdk-mainloop/.idea/gradle.xml
+index 526b4c2..a2d7c21 100644
+--- a/examples/agdk-mainloop/.idea/gradle.xml
++++ b/examples/agdk-mainloop/.idea/gradle.xml
+@@ -13,7 +13,6 @@
+             <option value="$PROJECT_DIR$/app" />
+           </set>
+         </option>
+-        <option name="resolveModulePerSourceSet" value="false" />
+       </GradleProjectSettings>
+     </option>
+   </component>
+diff --git a/examples/agdk-mainloop/src/lib.rs b/examples/agdk-mainloop/src/lib.rs
+index cb98354..6462b86 100644
+--- a/examples/agdk-mainloop/src/lib.rs
++++ b/examples/agdk-mainloop/src/lib.rs
+@@ -11,7 +11,7 @@ fn android_main(app: AndroidApp) {
+ 
+     while !quit {
+         app.poll_events(
+-            Some(std::time::Duration::from_millis(500)), /* timeout */
++            Some(std::time::Duration::from_secs(1)), /* timeout */
+             |event| {
+                 match event {
+                     PollEvent::Wake => {
+@@ -49,6 +49,9 @@ fn android_main(app: AndroidApp) {
+                             MainEvent::RedrawNeeded { .. } => {
+                                 redraw_pending = true;
+                             }
++                            MainEvent::InputAvailable { .. } => {
++                                redraw_pending = true;
++                            }
+                             MainEvent::LowMemory => {}
+ 
+                             MainEvent::Destroy => quit = true,
+-- 
+2.41.0.windows.1
+

--- a/android-activity/game-activity-csrc/patches/README.md
+++ b/android-activity/game-activity-csrc/patches/README.md
@@ -1,0 +1,79 @@
+For integrating the C/C++ GameActivity glue code with `android-activity` and
+Rust we need to make a number of changes to the C/C++ code that comes from
+Google's agdk-libraries releases.
+
+# Patches
+
+To help track the changes we've made we add a copy of each patch applied to this
+directory.
+
+When we come to update to a new AGDK release we need to review each of these
+patches to determine whether they are still needed (some of them are bug fixes
+or fill in some missing features) and if so we can port that change across and
+create a new patch.
+
+Each commit that modifies Google's upstream GameActivity code should start with
+"GameActivity PATCH:" to also help with tracking them down via the Git log.
+
+# Other Modifications
+
+There are a few C symbols that need to be exported from the cdylib that's built
+for GameActivity to load at runtime but Rust/Cargo doesn't support compiling
+C/C++ code in a way that can export these symbols directly and we instead have
+to export wrappers from Rust code.
+
+At the bottom of GameActivity.cpp then
+`Java_com_google_androidgamesdk_GameActivity_loadNativeCode` should be given a
+`_C` suffix like `Java_com_google_androidgamesdk_GameActivity_loadNativeCode_C`
+
+At the bottom of `android_native_app_glue.c` and `android_native_app_glue.h`
+`GameActivity_onCreate` should also be given a `_C` suffix like
+`GameActivity_onCreate_C`
+
+Since we want to call the application's main function from Rust after
+initializing our own `AndroidApp` state, but we want to let applications use the
+same `android_main` symbol name then `android_main` should be renamed to
+`_rust_glue_entry` in `android_native_app_glue.h` and
+`android_native_app_glue.c`
+
+# Synchronizing with Upstream
+
+Upstream distribute `android_native_app_glue.c` and `GameActivity.cpp` code as a
+"prefab" that is bundled as part of a `GameActivity-release.aar` archive. The
+idea is that it's a build system agnostic way of bundling native glue code with
+archives that build systems can extract the code via a command line tool, along
+with some metadata to describe how it should be compiled.
+
+It's fairly easy to extract the C/C++ files and just integrate them in a way
+that suits Rust / Cargo better.
+
+`.aar` files are simply zip archives that can be unpacked and the files under
+`prefab/modules/game-activity/include` can be moved to `csrc/` in this repo,
+which will then be built by `build.rs` via the `cc` crate.
+
+The easiest way I found to get to the `GameActivity-release.aar` is to download
+the "express" agdk-libraries release from
+https://developer.android.com/games/agdk/download, and you should find
+`GameActivity-release.aar` at the top level of the archive after unpacking.
+
+The git repo for the source code can be found here:
+https://android.googlesource.com/platform/frameworks/opt/gamesdk/ with the
+prefab code under `GameActivity/prefab-src/modules/game-activity/include` -
+though it may be best to synchronize with official releases.
+
+# Current Version
+
+The current version of GameActivity glue code is from:
+https://android.googlesource.com/platform/frameworks/opt/gamesdk/  commit = e8c66318443e5c864395725d7e4416d5b46242f8
+
+This is from May 25 2022 (corresponding to AGDK 2022.0.0)
+
+# Breaking changes?
+
+We only want to require a backwards-incompatible version bump for
+`android-activity` for semver breaking changes - either in the Rust API or in
+the Java APIs for `NativeActivity` and `GameActivity`.
+
+Awkwardly AGDK GameActivity releases don't follow semver and so we have to audit
+the changes manually to determine whether there has been a semver breaking change
+in the Java APIs.


### PR DESCRIPTION
This digs up a few notes from when I first implemented that agkd-rust crate that later became android-activity.

Hopefully we can prune the set of patches that we're tracking the next time that we sync with a new AGDK GameActivity release.

TODO: It would be good to have improved workflow documentation for how we will pull in new AGDK releases.

TODO: We should also document some kind of policy for what kinds of changes will be considered semver breaking changes for the android-activity crate.