### PR TITLE
Rework `input_events` API and expose `KeyCharacterMap` bindings

### DIFF
--- a/android-activity/Cargo.toml
+++ b/android-activity/Cargo.toml
@@ -38,6 +38,7 @@ native-activity = []
 log = "0.4"
 jni-sys = "0.3"
 cesu8 = "1"
+jni = "0.21"
 ndk = "0.7"
 ndk-sys = "0.4"
 ndk-context = "0.1"
@@ -45,6 +46,7 @@ android-properties = "0.2"
 num_enum = "0.6"
 bitflags = "2.0"
 libc = "0.2"
+thiserror = "1"
 
 [build-dependencies]
 cc = { version = "1.0", features = ["parallel"] }

--- a/android-activity/LICENSE
+++ b/android-activity/LICENSE
@@ -1,12 +1,24 @@
-The third-party glue code, under the native-activity-csrc/ and game-activity-csrc/ directories
-is covered by the Apache 2.0 license only:
+# License
 
-Apache License, Version 2.0 (docs/LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0)
+## GameActivity
 
+The third-party glue code, under the game-activity-csrc/ directory is covered by
+the Apache 2.0 license only:
+
+Apache License, Version 2.0 (docs/LICENSE-APACHE or <http://www.apache.org/licenses/LICENSE-2.0>)
+
+## SDK Documentation
+
+Documentation for APIs that are direct bindings of Android platform APIs are covered
+by the Apache 2.0 license only:
+
+Apache License, Version 2.0 (docs/LICENSE-APACHE or <http://www.apache.org/licenses/LICENSE-2.0>)
+
+## android-activity
 
 All other code is dual-licensed under either
 
-* MIT License (docs/LICENSE-MIT or http://opensource.org/licenses/MIT)
-* Apache License, Version 2.0 (docs/LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0)
+- MIT License (docs/LICENSE-MIT or <http://opensource.org/licenses/MIT>)
+- Apache License, Version 2.0 (docs/LICENSE-APACHE or <http://www.apache.org/licenses/LICENSE-2.0>)
 
 at your option.

--- a/android-activity/src/error.rs
+++ b/android-activity/src/error.rs
@@ -1,0 +1,58 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum AppError {
+    #[error("Operation only supported from the android_main() thread: {0}")]
+    NonMainThread(String),
+
+    #[error("Java VM or JNI error, including Java exceptions")]
+    JavaError(String),
+
+    #[error("Input unavailable")]
+    InputUnavailable,
+}
+
+pub type Result<T> = std::result::Result<T, AppError>;
+
+// XXX: we don't want to expose jni-rs in the public API
+// so we have an internal error type that we can generally
+// use in the backends and then we can strip the error
+// in the frontend of the API.
+//
+// This way we avoid exposing a public trait implementation for
+// `From<jni::errors::Error>`
+#[derive(Error, Debug)]
+pub(crate) enum InternalAppError {
+    #[error("A JNI error")]
+    JniError(jni::errors::JniError),
+    #[error("A Java Exception was thrown via a JNI method call")]
+    JniException(String),
+    #[error("A Java VM error")]
+    JvmError(jni::errors::Error),
+    #[error("Input unavailable")]
+    InputUnavailable,
+}
+
+pub(crate) type InternalResult<T> = std::result::Result<T, InternalAppError>;
+
+impl From<jni::errors::Error> for InternalAppError {
+    fn from(value: jni::errors::Error) -> Self {
+        InternalAppError::JvmError(value)
+    }
+}
+impl From<jni::errors::JniError> for InternalAppError {
+    fn from(value: jni::errors::JniError) -> Self {
+        InternalAppError::JniError(value)
+    }
+}
+
+impl From<InternalAppError> for AppError {
+    fn from(value: InternalAppError) -> Self {
+        match value {
+            InternalAppError::JniError(err) => AppError::JavaError(err.to_string()),
+            InternalAppError::JniException(msg) => AppError::JavaError(msg),
+            InternalAppError::JvmError(err) => AppError::JavaError(err.to_string()),
+            InternalAppError::InputUnavailable => AppError::InputUnavailable,
+        }
+    }
+}

--- a/android-activity/src/game_activity/input.rs
+++ b/android-activity/src/game_activity/input.rs
@@ -16,7 +16,7 @@
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use std::convert::TryInto;
 
-use crate::game_activity::ffi::{GameActivityKeyEvent, GameActivityMotionEvent};
+use crate::activity_impl::ffi::{GameActivityKeyEvent, GameActivityMotionEvent};
 use crate::input::{Class, Source};
 
 // Note: try to keep this wrapper API compatible with the AInputEvent API if possible
@@ -1270,6 +1270,12 @@ impl<'a> KeyEvent<'a> {
     /// See [the KeyEvent docs](https://developer.android.com/reference/android/view/KeyEvent#getAction())
     #[inline]
     pub fn action(&self) -> KeyAction {
+        let action = self.ga_event.action as u32;
+        action.try_into().unwrap()
+    }
+
+    #[inline]
+    pub fn action_button(&self) -> KeyAction {
         let action = self.ga_event.action as u32;
         action.try_into().unwrap()
     }

--- a/android-activity/src/input.rs
+++ b/android-activity/src/input.rs
@@ -2,6 +2,10 @@ use bitflags::bitflags;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 
 pub use crate::activity_impl::input::*;
+use crate::InputStatus;
+
+mod sdk;
+pub use sdk::*;
 
 /// An enum representing the source of an [`MotionEvent`] or [`KeyEvent`]
 ///
@@ -119,4 +123,23 @@ pub struct TextInputState {
     ///
     /// If the resulting region is zero-sized, no region is marked (equivalent to passing `None`)
     pub compose_region: Option<TextSpan>,
+}
+
+/// An exclusive, lending iterator for input events
+pub struct InputIterator<'a> {
+    pub(crate) inner: crate::activity_impl::InputIteratorInner<'a>,
+}
+
+impl<'a> InputIterator<'a> {
+    /// Reads and handles the next input event by passing it to the given `callback`
+    ///
+    /// `callback` should return [`InputStatus::Unhandled`] for any input events that aren't directly
+    /// handled by the application, or else [`InputStatus::Handled`]. Unhandled events may lead to a
+    /// fallback interpretation of the event.
+    pub fn next<F>(&mut self, callback: F) -> bool
+    where
+        F: FnOnce(&crate::activity_impl::input::InputEvent) -> InputStatus,
+    {
+        self.inner.next(callback)
+    }
 }

--- a/android-activity/src/input/sdk.rs
+++ b/android-activity/src/input/sdk.rs
@@ -1,0 +1,358 @@
+use std::sync::Arc;
+
+use jni::{
+    objects::{GlobalRef, JClass, JMethodID, JObject, JStaticMethodID, JValue},
+    signature::{Primitive, ReturnType},
+    JNIEnv,
+};
+use jni_sys::jint;
+
+use crate::{
+    activity_impl::input::{Keycode, MetaState},
+    jni_utils::CloneJavaVM,
+};
+
+use crate::{
+    error::{AppError, InternalAppError},
+    jni_utils,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum KeyboardType {
+    /// A numeric (12-key) keyboard.
+    ///
+    /// A numeric keyboard supports text entry using a multi-tap approach. It may be necessary to tap a key multiple times to generate the desired letter or symbol.
+    ///
+    /// This type of keyboard is generally designed for thumb typing.
+    Numeric,
+
+    /// A keyboard with all the letters, but with more than one letter per key.
+    ///
+    /// This type of keyboard is generally designed for thumb typing.
+    Predictive,
+
+    /// A keyboard with all the letters, and maybe some numbers.
+    ///
+    /// An alphabetic keyboard supports text entry directly but may have a condensed layout with a small form factor. In contrast to a full keyboard, some symbols may only be accessible using special on-screen character pickers. In addition, to improve typing speed and accuracy, the framework provides special affordances for alphabetic keyboards such as auto-capitalization and toggled / locked shift and alt keys.
+    ///
+    /// This type of keyboard is generally designed for thumb typing.
+    Alpha,
+
+    /// A full PC-style keyboard.
+    ///
+    /// A full keyboard behaves like a PC keyboard. All symbols are accessed directly by pressing keys on the keyboard without on-screen support or affordances such as auto-capitalization.
+    ///
+    /// This type of keyboard is generally designed for full two hand typing.
+    Full,
+
+    /// A keyboard that is only used to control special functions rather than for typing.
+    ///
+    /// A special function keyboard consists only of non-printing keys such as HOME and POWER that are not actually used for typing.
+    SpecialFunction,
+
+    /// An unknown type of keyboard
+    Unknown(i32),
+}
+
+impl From<i32> for KeyboardType {
+    fn from(value: i32) -> Self {
+        match value {
+            1 => KeyboardType::Numeric,
+            2 => KeyboardType::Predictive,
+            3 => KeyboardType::Alpha,
+            4 => KeyboardType::Full,
+            5 => KeyboardType::SpecialFunction,
+            unknown => KeyboardType::Unknown(unknown),
+        }
+    }
+}
+impl From<KeyboardType> for i32 {
+    fn from(value: KeyboardType) -> i32 {
+        match value {
+            KeyboardType::Numeric => 1,
+            KeyboardType::Predictive => 2,
+            KeyboardType::Alpha => 3,
+            KeyboardType::Full => 4,
+            KeyboardType::SpecialFunction => 5,
+            KeyboardType::Unknown(unknown) => unknown,
+        }
+    }
+}
+
+/// Either represents, a unicode character or combining accent from a
+/// [`KeyCharacterMap`], or `None` for non-printable keys.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum KeyMapChar {
+    None,
+    Unicode(char),
+    CombiningAccent(char),
+}
+
+// I've also tried to think here about how to we could potentially automatically
+// generate a binding struct like `KeyCharacterMapBinding` with a procmacro and
+// so have intentionally limited the `Binding` being a very thin, un-opinionated
+// wrapper based on basic JNI types.
+
+/// Lower-level JNI binding for `KeyCharacterMap` class only holds 'static state
+/// and can be shared with an `Arc` ref count.
+///
+/// The separation here also neatly helps us separate `InternalAppError` from
+/// `AppError` for mapping JNI errors without exposing any `jni-rs` types in the
+/// public API.
+#[derive(Debug)]
+pub(crate) struct KeyCharacterMapBinding {
+    //vm: JavaVM,
+    klass: GlobalRef,
+    get_method_id: JMethodID,
+    get_dead_char_method_id: JStaticMethodID,
+    get_keyboard_type_method_id: JMethodID,
+}
+
+impl KeyCharacterMapBinding {
+    pub(crate) fn new(env: &mut JNIEnv) -> Result<Self, InternalAppError> {
+        let binding = env.with_local_frame::<_, _, InternalAppError>(10, |env| {
+            let klass = env.find_class("android/view/KeyCharacterMap")?; // Creates a local ref
+            Ok(Self {
+                get_method_id: env.get_method_id(&klass, "get", "(II)I")?,
+                get_dead_char_method_id: env.get_static_method_id(
+                    &klass,
+                    "getDeadChar",
+                    "(II)I",
+                )?,
+                get_keyboard_type_method_id: env.get_method_id(&klass, "getKeyboardType", "()I")?,
+                klass: env.new_global_ref(&klass)?,
+            })
+        })?;
+        Ok(binding)
+    }
+
+    pub fn get<'local>(
+        &self,
+        env: &'local mut JNIEnv,
+        key_map: impl AsRef<JObject<'local>>,
+        key_code: jint,
+        meta_state: jint,
+    ) -> Result<jint, InternalAppError> {
+        let key_map = key_map.as_ref();
+
+        // Safety:
+        // - we know our global `key_map` reference is non-null and valid.
+        // - we know `get_method_id` remains valid
+        // - we know that the signature of KeyCharacterMap::get is `(int, int) -> int`
+        // - we know this won't leak any local references as a side effect
+        //
+        // We know it's ok to unwrap the `.i()` value since we explicitly
+        // specify the return type as `Int`
+        let unicode = unsafe {
+            env.call_method_unchecked(
+                key_map,
+                self.get_method_id,
+                ReturnType::Primitive(Primitive::Int),
+                &[
+                    JValue::Int(key_code).as_jni(),
+                    JValue::Int(meta_state).as_jni(),
+                ],
+            )
+        }
+        .map_err(|err| jni_utils::clear_and_map_exception_to_err(env, err))?;
+        Ok(unicode.i().unwrap())
+    }
+
+    pub fn get_dead_char(
+        &self,
+        env: &mut JNIEnv,
+        accent_char: jint,
+        base_char: jint,
+    ) -> Result<jint, InternalAppError> {
+        // Safety:
+        // - we know `get_dead_char_method_id` remains valid
+        // - we know that KeyCharacterMap::getDeadKey is a static method
+        // - we know that the signature of KeyCharacterMap::getDeadKey is `(int, int) -> int`
+        // - we know this won't leak any local references as a side effect
+        //
+        // We know it's ok to unwrap the `.i()` value since we explicitly
+        // specify the return type as `Int`
+
+        // Urgh, it's pretty terrible that there's no ergonomic/safe way to get a JClass reference from a GlobalRef
+        // Safety: we don't do anything that would try to delete the JClass as if it were a real local reference
+        let klass = unsafe { JClass::from_raw(self.klass.as_obj().as_raw()) };
+        let unicode = unsafe {
+            env.call_static_method_unchecked(
+                &klass,
+                self.get_dead_char_method_id,
+                ReturnType::Primitive(Primitive::Int),
+                &[
+                    JValue::Int(accent_char).as_jni(),
+                    JValue::Int(base_char).as_jni(),
+                ],
+            )
+        }
+        .map_err(|err| jni_utils::clear_and_map_exception_to_err(env, err))?;
+        Ok(unicode.i().unwrap())
+    }
+
+    pub fn get_keyboard_type<'local>(
+        &self,
+        env: &'local mut JNIEnv,
+        key_map: impl AsRef<JObject<'local>>,
+    ) -> Result<jint, InternalAppError> {
+        let key_map = key_map.as_ref();
+
+        // Safety:
+        // - we know our global `key_map` reference is non-null and valid.
+        // - we know `get_keyboard_type_method_id` remains valid
+        // - we know that the signature of KeyCharacterMap::getKeyboardType is `() -> int`
+        // - we know this won't leak any local references as a side effect
+        //
+        // We know it's ok to unwrap the `.i()` value since we explicitly
+        // specify the return type as `Int`
+        Ok(unsafe {
+            env.call_method_unchecked(
+                key_map,
+                self.get_keyboard_type_method_id,
+                ReturnType::Primitive(Primitive::Int),
+                &[],
+            )
+        }
+        .map_err(|err| jni_utils::clear_and_map_exception_to_err(env, err))?
+        .i()
+        .unwrap())
+    }
+}
+
+/// Describes the keys provided by a keyboard device and their associated labels.
+#[derive(Clone, Debug)]
+pub struct KeyCharacterMap {
+    jvm: CloneJavaVM,
+    binding: Arc<KeyCharacterMapBinding>,
+    key_map: GlobalRef,
+}
+
+impl KeyCharacterMap {
+    pub(crate) fn new(
+        jvm: CloneJavaVM,
+        binding: Arc<KeyCharacterMapBinding>,
+        key_map: GlobalRef,
+    ) -> Self {
+        Self {
+            jvm,
+            binding,
+            key_map,
+        }
+    }
+
+    /// Gets the Unicode character generated by the specified [`Keycode`] and [`MetaState`] combination.
+    ///
+    /// Returns [`KeyMapChar::None`] if the key is not one that is used to type Unicode characters.
+    ///
+    /// Returns [`KeyMapChar::CombiningAccent`] if the key is a "dead key" that should be combined with
+    /// another to actually produce a character -- see [`KeyCharacterMap::get_dead_char`].
+    ///
+    /// # Errors
+    ///
+    /// Since this API needs to use JNI internally to call into the Android JVM it may return
+    /// a [`AppError::JavaError`] in case there is a spurious JNI error or an exception
+    /// is caught.
+    pub fn get(&self, key_code: Keycode, meta_state: MetaState) -> Result<KeyMapChar, AppError> {
+        let key_code: u32 = key_code.into();
+        let key_code = key_code as jni_sys::jint;
+        let meta_state: u32 = meta_state.0;
+        let meta_state = meta_state as jni_sys::jint;
+
+        // Since we expect this API to be called from the `main` thread then we expect to already be
+        // attached to the JVM
+        //
+        // Safety: there's no other JNIEnv in scope so this env can't be used to subvert the mutable
+        // borrow rules that ensure we can only add local references to the top JNI frame.
+        let mut env = self.jvm.get_env().map_err(|err| {
+            let err: InternalAppError = err.into();
+            err
+        })?;
+        let unicode = self
+            .binding
+            .get(&mut env, self.key_map.as_obj(), key_code, meta_state)?;
+        let unicode = unicode as u32;
+
+        const COMBINING_ACCENT: u32 = 0x80000000;
+        const COMBINING_ACCENT_MASK: u32 = !COMBINING_ACCENT;
+
+        if unicode == 0 {
+            Ok(KeyMapChar::None)
+        } else if unicode & COMBINING_ACCENT == COMBINING_ACCENT {
+            let accent = unicode & COMBINING_ACCENT_MASK;
+            // Safety: assumes Android key maps don't contain invalid unicode characters
+            Ok(KeyMapChar::CombiningAccent(unsafe {
+                char::from_u32_unchecked(accent)
+            }))
+        } else {
+            // Safety: assumes Android key maps don't contain invalid unicode characters
+            Ok(KeyMapChar::Unicode(unsafe {
+                char::from_u32_unchecked(unicode)
+            }))
+        }
+    }
+
+    /// Get the character that is produced by combining the dead key producing accent with the key producing character c.
+    ///
+    /// For example, ```get_dead_char('`', 'e')``` returns 'è'. `get_dead_char('^', ' ')` returns '^' and `get_dead_char('^', '^')` returns '^'.
+    ///
+    /// # Errors
+    ///
+    /// Since this API needs to use JNI internally to call into the Android JVM it may return
+    /// a [`AppError::JavaError`] in case there is a spurious JNI error or an exception
+    /// is caught.
+    pub fn get_dead_char(
+        &self,
+        accent_char: char,
+        base_char: char,
+    ) -> Result<Option<char>, AppError> {
+        let accent_char = accent_char as jni_sys::jint;
+        let base_char = base_char as jni_sys::jint;
+
+        // Since we expect this API to be called from the `main` thread then we expect to already be
+        // attached to the JVM
+        //
+        // Safety: there's no other JNIEnv in scope so this env can't be used to subvert the mutable
+        // borrow rules that ensure we can only add local references to the top JNI frame.
+        let mut env = self.jvm.get_env().map_err(|err| {
+            let err: InternalAppError = err.into();
+            err
+        })?;
+        let unicode = self
+            .binding
+            .get_dead_char(&mut env, accent_char, base_char)?;
+        let unicode = unicode as u32;
+
+        // Safety: assumes Android key maps don't contain invalid unicode characters
+        Ok(if unicode == 0 {
+            None
+        } else {
+            Some(unsafe { char::from_u32_unchecked(unicode) })
+        })
+    }
+
+    /// Gets the keyboard type.
+    ///
+    /// Different keyboard types have different semantics. See [`KeyboardType`] for details.
+    ///
+    /// # Errors
+    ///
+    /// Since this API needs to use JNI internally to call into the Android JVM it may return
+    /// a [`AppError::JavaError`] in case there is a spurious JNI error or an exception
+    /// is caught.
+    pub fn get_keyboard_type(&self) -> Result<KeyboardType, AppError> {
+        // Since we expect this API to be called from the `main` thread then we expect to already be
+        // attached to the JVM
+        //
+        // Safety: there's no other JNIEnv in scope so this env can't be used to subvert the mutable
+        // borrow rules that ensure we can only add local references to the top JNI frame.
+        let mut env = self.jvm.get_env().map_err(|err| {
+            let err: InternalAppError = err.into();
+            err
+        })?;
+        let keyboard_type = self
+            .binding
+            .get_keyboard_type(&mut env, self.key_map.as_obj())?;
+        Ok(keyboard_type.into())
+    }
+}

--- a/android-activity/src/jni_utils.rs
+++ b/android-activity/src/jni_utils.rs
@@ -1,0 +1,151 @@
+//! The JNI calls we make in this crate are often not part of a Java native
+//! method implementation and so we can't assume we have a JNI local frame that
+//! is going to unwind and free local references, and we also can't just leave
+//! exceptions to get thrown when returning to Java.
+//!
+//! These utilities help us check + clear exceptions and map them into Rust Errors.
+
+use std::{ops::Deref, sync::Arc};
+
+use jni::{
+    objects::{JObject, JString},
+    JavaVM,
+};
+
+use crate::{
+    error::{InternalAppError, InternalResult},
+    input::{KeyCharacterMap, KeyCharacterMapBinding},
+};
+
+// TODO: JavaVM should implement Clone
+#[derive(Debug)]
+pub(crate) struct CloneJavaVM {
+    pub jvm: JavaVM,
+}
+impl Clone for CloneJavaVM {
+    fn clone(&self) -> Self {
+        Self {
+            jvm: unsafe { JavaVM::from_raw(self.jvm.get_java_vm_pointer()).unwrap() },
+        }
+    }
+}
+impl CloneJavaVM {
+    pub unsafe fn from_raw(jvm: *mut jni_sys::JavaVM) -> InternalResult<Self> {
+        Ok(Self {
+            jvm: JavaVM::from_raw(jvm)?,
+        })
+    }
+}
+unsafe impl Send for CloneJavaVM {}
+unsafe impl Sync for CloneJavaVM {}
+
+impl Deref for CloneJavaVM {
+    type Target = JavaVM;
+
+    fn deref(&self) -> &Self::Target {
+        &self.jvm
+    }
+}
+
+/// Use with `.map_err()` to map `jni::errors::Error::JavaException` into a
+/// richer error based on the actual contents of the `JThrowable`
+///
+/// (The `jni` crate doesn't do that automatically since it's more
+/// common to let the exception get thrown when returning to Java)
+///
+/// This will also clear the exception
+pub(crate) fn clear_and_map_exception_to_err(
+    env: &mut jni::JNIEnv<'_>,
+    err: jni::errors::Error,
+) -> InternalAppError {
+    if matches!(err, jni::errors::Error::JavaException) {
+        let result = env.with_local_frame::<_, _, InternalAppError>(5, |env| {
+            let e = env.exception_occurred()?;
+            assert!(!e.is_null()); // should only be called after receiving a JavaException Result
+            env.exception_clear()?;
+
+            let class = env.get_object_class(&e)?;
+            //let get_stack_trace_method = env.get_method_id(&class, "getStackTrace", "()[Ljava/lang/StackTraceElement;")?;
+            let get_message_method =
+                env.get_method_id(&class, "getMessage", "()Ljava/lang/String;")?;
+
+            let msg = unsafe {
+                env.call_method_unchecked(
+                    &e,
+                    get_message_method,
+                    jni::signature::ReturnType::Object,
+                    &[],
+                )?
+                .l()
+                .unwrap()
+            };
+            let msg = unsafe { JString::from_raw(JObject::into_raw(msg)) };
+            let msg = env.get_string(&msg)?;
+            let msg: String = msg.into();
+
+            // TODO: get Java backtrace:
+            /*
+            if let JValue::Object(elements) = env.call_method_unchecked(&e, get_stack_trace_method, jni::signature::ReturnType::Array, &[])? {
+                let elements = env.auto_local(elements);
+
+            }
+            */
+
+            Ok(msg)
+        });
+
+        match result {
+            Ok(msg) => InternalAppError::JniException(msg),
+            Err(err) => InternalAppError::JniException(format!(
+                "UNKNOWN (Failed to query JThrowable: {err:?})"
+            )),
+        }
+    } else {
+        err.into()
+    }
+}
+
+pub(crate) fn device_key_character_map(
+    jvm: CloneJavaVM,
+    key_map_binding: Arc<KeyCharacterMapBinding>,
+    device_id: i32,
+) -> InternalResult<KeyCharacterMap> {
+    // Don't really need to 'attach' since this should be called from the app's main thread that
+    // should already be attached, but the redundancy should be fine
+    //
+    // Attach 'permanently' to avoid any chance of detaching the thread from the VM
+    let mut env = jvm.attach_current_thread_permanently()?;
+
+    // We don't want to accidentally leak any local references while we
+    // aren't going to be returning from here back to the JVM, to unwind, so
+    // we make a local frame
+    let character_map = env.with_local_frame::<_, _, jni::errors::Error>(10, |env| {
+        let input_device_class = env.find_class("android/view/InputDevice")?; // Creates a local ref
+        let device = env
+            .call_static_method(
+                input_device_class,
+                "getDevice",
+                "(I)Landroid/view/InputDevice;",
+                &[device_id.into()],
+            )?
+            .l()?; // Creates a local ref
+
+        let character_map = env
+            .call_method(
+                &device,
+                "getKeyCharacterMap",
+                "()Landroid/view/KeyCharacterMap;",
+                &[],
+            )?
+            .l()?;
+        let character_map = env.new_global_ref(character_map)?;
+
+        Ok(character_map)
+    })?;
+
+    Ok(KeyCharacterMap::new(
+        jvm.clone(),
+        key_map_binding,
+        character_map,
+    ))
+}

--- a/android-activity/src/native_activity/input.rs
+++ b/android-activity/src/native_activity/input.rs
@@ -326,6 +326,15 @@ impl<'a> KeyEvent<'a> {
     pub fn scan_code(&self) -> i32 {
         self.ndk_event.scan_code()
     }
+
+    /// Returns the state of the modifiers during this key event, represented by a bitmask.
+    ///
+    /// See [the NDK
+    /// docs](https://developer.android.com/ndk/reference/group/input#akeyevent_getmetastate)
+    #[inline]
+    pub fn meta_state(&self) -> MetaState {
+        self.ndk_event.meta_state()
+    }
 }
 
 // We use our own wrapper type for input events to have better consistency


### PR DESCRIPTION
_(Note: I've marked as draft while I still need to update the docs more)_

With the way events are delivered via an `InputQueue` with `NativeActivity` there is no direct access to the underlying KeyEvent and MotionEvent Java objects and no `ndk` API that supports the equivalent of `KeyEvent.getUnicodeChar()`

What `getUnicodeChar` does under the hood though is lookup into a `KeyCharacterMap` for the corresponding `InputDevice` based on the event's `key_code` and `meta_state` - which we can do via some JNI bindings for `KeyCharacterMap`.

Although it's still awkward to expose an API like
`key_event.get_unicode_char()` we can instead provide an API that lets you look up a `KeyCharacterMap` for any `device_id` and applications can then use that for character mapping.

This approach is also more general than the `getUnicodeChar` utility since it exposes other useful state, such as being able to check what kind of keyboard input events are coming from (such as a full physical keyboard vs a virtual / 'predictive' keyboard)

For consistency this exposes the same API through the game-activity backend, even though the game-activity backend is technically able to support unicode lookups via `getUnicodeChar` (since it has access to the Java `KeyEvent` object).

This highlighted a need to be able to use other `AndroidApp` APIs while processing input, which wasn't possible with the `.input_events()` API design because the `AndroidApp` held a lock over the backend while iterating events.

This changes `input_events()` to `input_events_iter()` which now returns a form of lending iterator and instead of taking a callback that gets called repeatedly by `input_events()` a similar callback is now passed to `iter.next(callback)`.

Code that iterates events now looks something like:

```rust
match app.input_events_iter() {
    Ok(mut iter) => {
        loop {
            let read_input = iter.next(|event| {
                let handled = match event {
                    InputEvent::KeyEvent(key_event) => {
                        // Snip
                    }
                    InputEvent::MotionEvent(motion_event) => {
                        // Snip
                    }
                    event => {
                        // Snip
                    }
                };

                handled
            });

            if !read_input {
                break;
            }
        }
    }
    Err(err) => {
        log::error!("Failed to get input events iterator: {err:?}");
    }
}
```

Code to handle unicode character mapping, including handling dead key handling would look something like:
```rust
let mut combining_accent = None;
// Snip


let combined_key_char = if let Ok(map) = app.device_key_character_map(device_id) {
    match map.get(key_event.key_code(), key_event.meta_state()) {
        Ok(KeyMapChar::Unicode(unicode)) => {
            let combined_unicode = if let Some(accent) = combining_accent {
                match map.get_dead_key(accent, unicode) {
                    Ok(Some(key)) => {
                        info!("KeyEvent: Combined '{unicode}' with accent '{accent}' to give '{key}'");
                        Some(key)
                    }
                    Ok(None) => None,
                    Err(err) => {
                        log::error!("KeyEvent: Failed to combine 'dead key' accent '{accent}' with '{unicode}': {err:?}");
                        None
                    }
                }
            } else {
                info!("KeyEvent: Pressed '{unicode}'");
                Some(unicode)
            };
            combining_accent = None;
            combined_unicode.map(|unicode| KeyMapChar::Unicode(unicode))
        }
        Ok(KeyMapChar::CombiningAccent(accent)) => {
            info!("KeyEvent: Pressed 'dead key' combining accent '{accent}'");
            combining_accent = Some(accent);
            Some(KeyMapChar::CombiningAccent(accent))
        }
        Ok(KeyMapChar::None) => {
            info!("KeyEvent: Pressed non-unicode key");
            combining_accent = None;
            None
        }
        Err(err) => {
            log::error!("KeyEvent: Failed to get key map character: {err:?}");
            combining_accent = None;
            None
        }
    }
} else {
    None
};
```

The API isn't as ergonomic as I would have liked, considering that lending iterators aren't a standard feature for Rust yet but also since we still want to have the handling for each individual event go via a callback that can report whether an event was "handled". I think the slightly awkward ergonomics are acceptable though considering that the API will generally be used as an implementation detail within middleware frameworks like Winit.

Since this is the first example where we're creating non-trivial Java bindings for an Android SDK API this adds some JNI utilities and establishes a pattern for how we can implement a class binding.

There is now a public Error and Result type that can convey JNI errors (but without exposing any `jni-rs` types in the public API) as well as failures to get an input iterator (which could happen if an app attempted to get more than one iterator at the same time).

It's an implementation detail but with how I wrote the binding I tried to keep in mind the possibility of creating a procmacro later that would generate some of the JNI boilerplate involved.