### PR TITLE
Bump MSRV to 1.68

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         # See top README for MSRV policy
-        rust_version: [1.64.0, stable]
+        rust_version: [1.68.0, stable]
     steps:
       - uses: actions/checkout@v3
 
@@ -34,9 +34,7 @@ jobs:
           i686-linux-android
 
       - name: Install cargo-ndk
-        # We're currently sticking with cargo-ndk 2, until we bump our
-        # MSRV to 1.68+
-        run: cargo install cargo-ndk --version "^2"
+        run: cargo install cargo-ndk
 
       - name: Setup Java
         uses: actions/setup-java@v3

--- a/android-activity/Cargo.toml
+++ b/android-activity/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/rust-mobile/android-activity"
 documentation = "https://docs.rs/android-activity"
 description = "Glue for building Rust applications on Android with NativeActivity or GameActivity"
 license = "MIT OR Apache-2.0"
-rust-version = "1.64"
+rust-version = "1.68.0"
 
 [features]
 # Note: we don't enable any backend by default since features

--- a/android-activity/src/game_activity/mod.rs
+++ b/android-activity/src/game_activity/mod.rs
@@ -759,7 +759,6 @@ extern "Rust" {
 // `app_main` function. This is run on a dedicated thread spawned
 // by android_native_app_glue.
 #[no_mangle]
-#[allow(unused_unsafe)] // Otherwise rust 1.64 moans about using unsafe{} in unsafe functions
 pub unsafe extern "C" fn _rust_glue_entry(native_app: *mut ffi::android_app) {
     abort_on_panic(|| {
         // Maybe make this stdout/stderr redirection an optional / opt-in feature?...

--- a/android-activity/src/native_activity/glue.rs
+++ b/android-activity/src/native_activity/glue.rs
@@ -828,7 +828,6 @@ unsafe extern "C" fn on_content_rect_changed(
 
 /// This is the native entrypoint for our cdylib library that `ANativeActivity` will look for via `dlsym`
 #[no_mangle]
-#[allow(unused_unsafe)] // Otherwise rust 1.64 moans about using unsafe{} in unsafe functions
 extern "C" fn ANativeActivity_onCreate(
     activity: *mut ndk_sys::ANativeActivity,
     saved_state: *const libc::c_void,


### PR DESCRIPTION
- Lets us build with cargo ndk 3+
- Lets us remove suppression for false-negative clippy warning about unsafe blocks in unsafe functions
- Should unblock CI for #102

- 1.68.0 notably also builds the standard library with a newer r25 NDK toolchain which avoids the need for awkward libgcc workarounds, so it's anyway a desirable baseline for Android projects.