### PR TITLE
Revert 'Bump MSRV to 1.68'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # See top README for MSRV policy
-        rust_version: [1.68.0, stable]
+        # XXX: We are currently constrained by Winit's MSRV policy + CI system
+        # See Cargo.toml for details
+        rust_version: [1.64.0, stable]
     steps:
       - uses: actions/checkout@v3
 
@@ -34,7 +35,10 @@ jobs:
           i686-linux-android
 
       - name: Install cargo-ndk
-        run: cargo install cargo-ndk
+        # XXX: We have to use an old version of cargo-ndk that supports the
+        # libgcc linker workaround for rust < 1.68 because Winit's CI system
+        # currently requires this crate to be buildable with 1.64
+        run: cargo install cargo-ndk --version "^2"
 
       - name: Setup Java
         uses: actions/setup-java@v3

--- a/android-activity/Cargo.toml
+++ b/android-activity/Cargo.toml
@@ -9,7 +9,19 @@ repository = "https://github.com/rust-mobile/android-activity"
 documentation = "https://docs.rs/android-activity"
 description = "Glue for building Rust applications on Android with NativeActivity or GameActivity"
 license = "MIT OR Apache-2.0"
-rust-version = "1.68.0"
+
+# XXX: Even though we have our own MSRV policy that says we only promise to
+# support stable releases over the last three months we actually end up
+# constrained by the MSRV policy of Winit, which is currently based on
+# supporting Alacritty on Debian Sid, and requires a > 10 month old Rust version
+#
+# This Winit policiy is unfortunately in conflict with what makes sense for
+# Android because versions below 1.68 for Android requires awkward toolchain
+# linker workarounds, and can't even be compiled with newer versions of
+# `cargo ndk` that removed these linker workarounds.
+#
+# TODO: Open a PR for Winit's CI to test Android builds using a newer toolchain.
+rust-version = "1.64"
 
 [features]
 # Note: we don't enable any backend by default since features

--- a/android-activity/src/game_activity/mod.rs
+++ b/android-activity/src/game_activity/mod.rs
@@ -759,6 +759,7 @@ extern "Rust" {
 // `app_main` function. This is run on a dedicated thread spawned
 // by android_native_app_glue.
 #[no_mangle]
+#[allow(unused_unsafe)] // Otherwise rust 1.64 moans about using unsafe{} in unsafe functions
 pub unsafe extern "C" fn _rust_glue_entry(native_app: *mut ffi::android_app) {
     abort_on_panic(|| {
         // Maybe make this stdout/stderr redirection an optional / opt-in feature?...

--- a/android-activity/src/native_activity/glue.rs
+++ b/android-activity/src/native_activity/glue.rs
@@ -828,6 +828,7 @@ unsafe extern "C" fn on_content_rect_changed(
 
 /// This is the native entrypoint for our cdylib library that `ANativeActivity` will look for via `dlsym`
 #[no_mangle]
+#[allow(unused_unsafe)] // Otherwise rust 1.64 moans about using unsafe{} in unsafe functions
 extern "C" fn ANativeActivity_onCreate(
     activity: *mut ndk_sys::ANativeActivity,
     saved_state: *const libc::c_void,


### PR DESCRIPTION
This effectively reverts 66cfc68dac2a28e584c02f0ee4278fa7376aafee (from #103) and adds some comments explaining that we're currently blocked by Winit's MSRV policy + CI from being able to increase our rust-version.

This is a frustrating conflict that I hope can be addressed by updating Winit's CI system to allow different platforms to require more recent versions of Rust (which notably isn't in conflict with setting a conservative rust-version in Winit for supporting Debian on Linux)

This re-instates building android-activity with cargo-ndk 2 because building on Android with 1.64 requires a linker workaround that's not implemented in newer version of cargo-ndk.

This also reinstates the clippy false-negative warning suppression for unsafe blocks. Again it's frustrating that we can't have good things because of how Winit wants to support Debian which shouldn't be relevant for Android development.

Here is an upstream issue to discuss a potential solution for this: https://github.com/rust-windowing/winit/issues/3000