### PR TITLE
GameActivity PATCH: Don't read unicode via getUnicodeChar

### DIFF
--- a/android-activity/game-activity-csrc/game-activity/GameActivityEvents.cpp
+++ b/android-activity/game-activity-csrc/game-activity/GameActivityEvents.cpp
@@ -345,7 +345,7 @@ static struct {
     jmethodID getRepeatCount;
     jmethodID getKeyCode;
     jmethodID getScanCode;
-    jmethodID getUnicodeChar;
+    //jmethodID getUnicodeChar;
 } gKeyEventClassInfo;
 
 extern "C" void GameActivityKeyEvent_fromJava(JNIEnv *env, jobject keyEvent,
@@ -379,8 +379,8 @@ extern "C" void GameActivityKeyEvent_fromJava(JNIEnv *env, jobject keyEvent,
             env->GetMethodID(keyEventClass, "getKeyCode", "()I");
         gKeyEventClassInfo.getScanCode =
             env->GetMethodID(keyEventClass, "getScanCode", "()I");
-        gKeyEventClassInfo.getUnicodeChar =
-            env->GetMethodID(keyEventClass, "getUnicodeChar", "()I");
+        //gKeyEventClassInfo.getUnicodeChar =
+        //    env->GetMethodID(keyEventClass, "getUnicodeChar", "()I");
 
         gKeyEventClassInfoInitialized = true;
     }
@@ -407,7 +407,8 @@ extern "C" void GameActivityKeyEvent_fromJava(JNIEnv *env, jobject keyEvent,
         /*keyCode=*/
         env->CallIntMethod(keyEvent, gKeyEventClassInfo.getKeyCode),
         /*scanCode=*/
-        env->CallIntMethod(keyEvent, gKeyEventClassInfo.getScanCode),
+        env->CallIntMethod(keyEvent, gKeyEventClassInfo.getScanCode)
         /*unicodeChar=*/
-        env->CallIntMethod(keyEvent, gKeyEventClassInfo.getUnicodeChar)};
+        //env->CallIntMethod(keyEvent, gKeyEventClassInfo.getUnicodeChar)
+    };
 }

--- a/android-activity/game-activity-csrc/game-activity/GameActivityEvents.h
+++ b/android-activity/game-activity-csrc/game-activity/GameActivityEvents.h
@@ -312,7 +312,7 @@ typedef struct GameActivityKeyEvent {
     int32_t repeatCount;
     int32_t keyCode;
     int32_t scanCode;
-    int32_t unicodeChar;
+    //int32_t unicodeChar;
 } GameActivityKeyEvent;
 
 /**

--- a/android-activity/src/game_activity/ffi_aarch64.rs
+++ b/android-activity/src/game_activity/ffi_aarch64.rs
@@ -2686,7 +2686,6 @@ pub struct GameActivityKeyEvent {
     pub repeatCount: i32,
     pub keyCode: i32,
     pub scanCode: i32,
-    pub unicodeChar: i32,
 }
 #[test]
 fn bindgen_test_layout_GameActivityKeyEvent() {
@@ -2694,7 +2693,7 @@ fn bindgen_test_layout_GameActivityKeyEvent() {
     let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<GameActivityKeyEvent>(),
-        64usize,
+        56usize,
         concat!("Size of: ", stringify!(GameActivityKeyEvent))
     );
     assert_eq!(
@@ -2810,16 +2809,6 @@ fn bindgen_test_layout_GameActivityKeyEvent() {
             stringify!(GameActivityKeyEvent),
             "::",
             stringify!(scanCode)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).unicodeChar) as usize - ptr as usize },
-        56usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(GameActivityKeyEvent),
-            "::",
-            stringify!(unicodeChar)
         )
     );
 }

--- a/android-activity/src/game_activity/ffi_arm.rs
+++ b/android-activity/src/game_activity/ffi_arm.rs
@@ -2716,7 +2716,6 @@ pub struct GameActivityKeyEvent {
     pub repeatCount: i32,
     pub keyCode: i32,
     pub scanCode: i32,
-    pub unicodeChar: i32,
 }
 #[test]
 fn bindgen_test_layout_GameActivityKeyEvent() {
@@ -2724,7 +2723,7 @@ fn bindgen_test_layout_GameActivityKeyEvent() {
     let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<GameActivityKeyEvent>(),
-        64usize,
+        56usize,
         concat!("Size of: ", stringify!(GameActivityKeyEvent))
     );
     assert_eq!(
@@ -2840,16 +2839,6 @@ fn bindgen_test_layout_GameActivityKeyEvent() {
             stringify!(GameActivityKeyEvent),
             "::",
             stringify!(scanCode)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).unicodeChar) as usize - ptr as usize },
-        56usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(GameActivityKeyEvent),
-            "::",
-            stringify!(unicodeChar)
         )
     );
 }

--- a/android-activity/src/game_activity/ffi_i686.rs
+++ b/android-activity/src/game_activity/ffi_i686.rs
@@ -2637,7 +2637,6 @@ pub struct GameActivityKeyEvent {
     pub repeatCount: i32,
     pub keyCode: i32,
     pub scanCode: i32,
-    pub unicodeChar: i32,
 }
 #[test]
 fn bindgen_test_layout_GameActivityKeyEvent() {
@@ -2645,7 +2644,7 @@ fn bindgen_test_layout_GameActivityKeyEvent() {
     let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<GameActivityKeyEvent>(),
-        56usize,
+        52usize,
         concat!("Size of: ", stringify!(GameActivityKeyEvent))
     );
     assert_eq!(
@@ -2761,16 +2760,6 @@ fn bindgen_test_layout_GameActivityKeyEvent() {
             stringify!(GameActivityKeyEvent),
             "::",
             stringify!(scanCode)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).unicodeChar) as usize - ptr as usize },
-        52usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(GameActivityKeyEvent),
-            "::",
-            stringify!(unicodeChar)
         )
     );
 }

--- a/android-activity/src/game_activity/ffi_x86_64.rs
+++ b/android-activity/src/game_activity/ffi_x86_64.rs
@@ -2666,7 +2666,6 @@ pub struct GameActivityKeyEvent {
     pub repeatCount: i32,
     pub keyCode: i32,
     pub scanCode: i32,
-    pub unicodeChar: i32,
 }
 #[test]
 fn bindgen_test_layout_GameActivityKeyEvent() {
@@ -2674,7 +2673,7 @@ fn bindgen_test_layout_GameActivityKeyEvent() {
     let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<GameActivityKeyEvent>(),
-        64usize,
+        56usize,
         concat!("Size of: ", stringify!(GameActivityKeyEvent))
     );
     assert_eq!(
@@ -2790,16 +2789,6 @@ fn bindgen_test_layout_GameActivityKeyEvent() {
             stringify!(GameActivityKeyEvent),
             "::",
             stringify!(scanCode)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).unicodeChar) as usize - ptr as usize },
-        56usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(GameActivityKeyEvent),
-            "::",
-            stringify!(unicodeChar)
         )
     );
 }


### PR DESCRIPTION
The `unicodeChar` in `GameActivityKeyEvent` wasn't being exposed by `android-activity` because we couldn't expose the unicode character in the same way with the native-activity backend - due to how events are received via an `InputQueue` that doesn't expose the underlying Java references for the key events.

Now that we have a consistent way of supporting unicode character mapping via `KeyCharacterMap` bindings it's redundant for the `GameActivity` backend to call `getUnicodeChar` automatically for each key press.