### PR TITLE
Bump MSRV to 1.68

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # XXX: We are currently constrained by Winit's MSRV policy + CI system
-        # See Cargo.toml for details
-        rust_version: [1.64.0, stable]
+        # See top README for MSRV policy
+        rust_version: [1.68.0, stable]
     steps:
       - uses: actions/checkout@v3
 
@@ -35,10 +34,7 @@ jobs:
           i686-linux-android
 
       - name: Install cargo-ndk
-        # XXX: We have to use an old version of cargo-ndk that supports the
-        # libgcc linker workaround for rust < 1.68 because Winit's CI system
-        # currently requires this crate to be buildable with 1.64
-        run: cargo install cargo-ndk --version "^2"
+        run: cargo install cargo-ndk
 
       - name: Build game-activity
         working-directory: android-activity

--- a/android-activity/Cargo.toml
+++ b/android-activity/Cargo.toml
@@ -10,18 +10,12 @@ documentation = "https://docs.rs/android-activity"
 description = "Glue for building Rust applications on Android with NativeActivity or GameActivity"
 license = "MIT OR Apache-2.0"
 
-# XXX: Even though we have our own MSRV policy that says we only promise to
-# support stable releases over the last three months we actually end up
-# constrained by the MSRV policy of Winit, which is currently based on
-# supporting Alacritty on Debian Sid, and requires a > 10 month old Rust version
+# 1.68 was when Rust last updated the Android NDK version used to build the
+# standard library which avoids needing the -lunwind workaround in build tools.
 #
-# This Winit policiy is unfortunately in conflict with what makes sense for
-# Android because versions below 1.68 for Android requires awkward toolchain
-# linker workarounds, and can't even be compiled with newer versions of
-# `cargo ndk` that removed these linker workarounds.
-#
-# TODO: Open a PR for Winit's CI to test Android builds using a newer toolchain.
-rust-version = "1.64"
+# We depend on cargo-ndk for building which has dropped support for the above
+# linker workaround.
+rust-version = "1.68.0"
 
 [features]
 # Note: we don't enable any backend by default since features

--- a/android-activity/src/game_activity/mod.rs
+++ b/android-activity/src/game_activity/mod.rs
@@ -909,7 +909,6 @@ extern "Rust" {
 // `app_main` function. This is run on a dedicated thread spawned
 // by android_native_app_glue.
 #[no_mangle]
-#[allow(unused_unsafe)] // Otherwise rust 1.64 moans about using unsafe{} in unsafe functions
 pub unsafe extern "C" fn _rust_glue_entry(native_app: *mut ffi::android_app) {
     abort_on_panic(|| {
         // Maybe make this stdout/stderr redirection an optional / opt-in feature?...

--- a/android-activity/src/native_activity/glue.rs
+++ b/android-activity/src/native_activity/glue.rs
@@ -828,7 +828,6 @@ unsafe extern "C" fn on_content_rect_changed(
 
 /// This is the native entrypoint for our cdylib library that `ANativeActivity` will look for via `dlsym`
 #[no_mangle]
-#[allow(unused_unsafe)] // Otherwise rust 1.64 moans about using unsafe{} in unsafe functions
 extern "C" fn ANativeActivity_onCreate(
     activity: *mut ndk_sys::ANativeActivity,
     saved_state: *const libc::c_void,


### PR DESCRIPTION
This is a redo of https://github.com/rust-mobile/android-activity/pull/103 now that Winit has updated its CI to not build its Android backend against its strict MSRV, primarily aimed at supporting Debian on Linux.

- Lets us build with cargo ndk 3+
- Lets us remove suppression for false-negative clippy warning about unsafe blocks in unsafe functions

1.68.0 notably builds the standard library with a newer r25 NDK toolchain which avoid the need for awkward libgcc workarounds, so it's anyway a desirable baseline for Android projects.