### PR TITLE
Enable CI on all branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: ci
 
 on:
   push:
-    branches: [main]
+    branches: '*'
   pull_request:
 
 env:


### PR DESCRIPTION
Enabling CI on all branches makes it smoother for external contributors, who can check CI status before creating a PR and awaiting approval of a workflow run.

For pull requests the behaviour in this repository is the same - a workflow run on a PR still requires approval. But for forks, this helps out with faster CI feedback.