### PR TITLE
Set `workspace.resolver = "2"` and avoid cargo warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = ["android-activity"]
 
 exclude = ["examples"]


### PR DESCRIPTION
Since we're using `edition = "2021"` in `android-activity/Cargo.toml` (which defaults to the v2 resolver) then cargo warns that this isn't consistent with the v1 resolver default for the top-level workspace.