### PR TITLE
Expose MotionEvent::action_button() state

### DIFF
--- a/android-activity/src/game_activity/input.rs
+++ b/android-activity/src/game_activity/input.rs
@@ -15,8 +15,8 @@
 
 use crate::activity_impl::ffi::{GameActivityKeyEvent, GameActivityMotionEvent};
 use crate::input::{
-    Axis, ButtonState, EdgeFlags, KeyAction, KeyEventFlags, Keycode, MetaState, MotionAction,
-    MotionEventFlags, Pointer, PointersIter, Source, ToolType,
+    Axis, Button, ButtonState, EdgeFlags, KeyAction, KeyEventFlags, Keycode, MetaState,
+    MotionAction, MotionEventFlags, Pointer, PointersIter, Source, ToolType,
 };
 
 // Note: try to keep this wrapper API compatible with the AInputEvent API if possible
@@ -64,6 +64,18 @@ impl<'a> MotionEvent<'a> {
     #[inline]
     pub fn action(&self) -> MotionAction {
         let action = self.ga_event.action as u32 & ndk_sys::AMOTION_EVENT_ACTION_MASK;
+        action.into()
+    }
+
+    /// Returns which button has been modified during a press or release action.
+    ///
+    /// For actions other than [`MotionAction::ButtonPress`] and
+    /// [`MotionAction::ButtonRelease`] the returned value is undefined.
+    ///
+    /// See [the MotionEvent docs](https://developer.android.com/reference/android/view/MotionEvent#getActionButton())
+    #[inline]
+    pub fn action_button(&self) -> Button {
+        let action = self.ga_event.actionButton as u32;
         action.into()
     }
 

--- a/android-activity/src/input.rs
+++ b/android-activity/src/input.rs
@@ -238,6 +238,37 @@ pub enum MotionAction {
     __Unknown(u32),
 }
 
+/// Identifies buttons that are associated with motion events.
+///
+/// See [the NDK
+/// docs](https://developer.android.com/ndk/reference/group/input#anonymous-enum-47)
+///
+/// # Android Extensible Enum
+///
+/// This is a runtime [extensible enum](`crate#android-extensible-enums`) and
+/// should be handled similar to a `#[non_exhaustive]` enum to maintain
+/// forwards compatibility.
+///
+/// This implements `Into<u32>` and `From<u32>` for converting to/from Android
+/// SDK integer values.
+///
+#[derive(Copy, Clone, Debug, PartialEq, Eq, num_enum::FromPrimitive, num_enum::IntoPrimitive)]
+#[non_exhaustive]
+#[repr(u32)]
+pub enum Button {
+    Back = ndk_sys::AMOTION_EVENT_BUTTON_BACK,
+    Forward = ndk_sys::AMOTION_EVENT_BUTTON_FORWARD,
+    Primary = ndk_sys::AMOTION_EVENT_BUTTON_PRIMARY,
+    Secondary = ndk_sys::AMOTION_EVENT_BUTTON_SECONDARY,
+    StylusPrimary = ndk_sys::AMOTION_EVENT_BUTTON_STYLUS_PRIMARY,
+    StylusSecondary = ndk_sys::AMOTION_EVENT_BUTTON_STYLUS_SECONDARY,
+    Tertiary = ndk_sys::AMOTION_EVENT_BUTTON_TERTIARY,
+
+    #[doc(hidden)]
+    #[num_enum(catch_all)]
+    __Unknown(u32),
+}
+
 /// An axis of a motion event.
 ///
 /// See [the NDK docs](https://developer.android.com/ndk/reference/group/input#anonymous-enum-32)

--- a/android-activity/src/native_activity/input.rs
+++ b/android-activity/src/native_activity/input.rs
@@ -51,10 +51,10 @@ impl<'a> MotionEvent<'a> {
     /// See [the MotionEvent docs](https://developer.android.com/reference/android/view/MotionEvent#getActionMasked())
     #[inline]
     pub fn action(&self) -> MotionAction {
-        // XXX: we use `AInputEvent_getAction` directly since we have our own
-        // `KeyAction` enum that we share between backends, which may also
+        // XXX: we use `AMotionEvent_getAction` directly since we have our own
+        // `MotionAction` enum that we share between backends, which may also
         // capture unknown variants added in new versions of Android.
-        let action = unsafe { ndk_sys::AKeyEvent_getAction(self.ndk_event.ptr().as_ptr()) as u32 };
+        let action = unsafe { ndk_sys::AMotionEvent_getAction(self.ndk_event.ptr().as_ptr()) as u32 };
         action.into()
     }
 

--- a/android-activity/src/native_activity/input.rs
+++ b/android-activity/src/native_activity/input.rs
@@ -1,8 +1,8 @@
 use std::marker::PhantomData;
 
 use crate::input::{
-    Axis, ButtonState, EdgeFlags, KeyAction, Keycode, MetaState, MotionAction, MotionEventFlags,
-    Pointer, PointersIter, Source, ToolType,
+    Axis, Button, ButtonState, EdgeFlags, KeyAction, Keycode, MetaState, MotionAction,
+    MotionEventFlags, Pointer, PointersIter, Source, ToolType,
 };
 
 /// A motion event
@@ -54,8 +54,22 @@ impl<'a> MotionEvent<'a> {
         // XXX: we use `AMotionEvent_getAction` directly since we have our own
         // `MotionAction` enum that we share between backends, which may also
         // capture unknown variants added in new versions of Android.
-        let action = unsafe { ndk_sys::AMotionEvent_getAction(self.ndk_event.ptr().as_ptr()) as u32 };
+        let action =
+            unsafe { ndk_sys::AMotionEvent_getAction(self.ndk_event.ptr().as_ptr()) as u32 };
         action.into()
+    }
+
+    /// Returns which button has been modified during a press or release action.
+    ///
+    /// For actions other than [`MotionAction::ButtonPress`] and
+    /// [`MotionAction::ButtonRelease`] the returned value is undefined.
+    ///
+    /// See [the MotionEvent docs](https://developer.android.com/reference/android/view/MotionEvent#getActionButton())
+    #[inline]
+    pub fn action_button(&self) -> Button {
+        let action_button =
+            unsafe { ndk_sys::AMotionEvent_getActionButton(self.ndk_event.ptr().as_ptr()) as u32 };
+        action_button.into()
     }
 
     /// Returns the pointer index of an `Up` or `Down` event.


### PR DESCRIPTION
This exposes the button associated with a button press or release action.

The PR also includes a separate copy&paste fix for `MotionEvent::action()` that was spotted while adding `action_button()`.