### PR TITLE
Disable `ndk` default features to remove `raw-window-handle 0.6`

### DIFF
--- a/android-activity/Cargo.toml
+++ b/android-activity/Cargo.toml
@@ -34,7 +34,7 @@ jni-sys = "0.3"
 cesu8 = "1"
 jni = "0.21"
 ndk-sys = "0.5.0"
-ndk = "0.8.0"
+ndk = { version = "0.8.0", default-features = false }
 ndk-context = "0.1"
 android-properties = "0.2"
 num_enum = "0.7"
@@ -54,3 +54,6 @@ targets = [
 ]
 
 rustdoc-args = ["--cfg", "docsrs"]
+
+[dev-dependencies]
+ndk = "0.8.0"


### PR DESCRIPTION
Fixes #141

The `ndk` crate enables `raw-window-handle 0.6` by default (because of https://github.com/rust-mobile/ndk/pull/434#issuecomment-1752089087) which might not be used by consumers of the `android-activity` crate at all, or might (still) be a mismatching version. Even if the `rwh_0x` features are additive, figuring that out leads to cryptic errors and it is best to turn off these defaults completely and leave it to the user to turn it back on in their own `[dependencies]` section if desired.

---

I couldn't run the test because of that error, I'm on mac, not sure how my android dev setup is right now 😅 
<img width="859" alt="image" src="https://github.com/rust-mobile/android-activity/assets/2290685/b8513acf-9909-4971-afa4-f89911d31168">
