### PR TITLE
Name spawned threads

### DIFF
--- a/android-activity/src/game_activity/mod.rs
+++ b/android-activity/src/game_activity/mod.rs
@@ -926,7 +926,7 @@ pub unsafe extern "C" fn _rust_glue_entry(native_app: *mut ffi::android_app) {
         };
 
         thread::Builder::new()
-            .name("android-stdio".to_string())
+            .name("stdio-to-logcat".to_string())
             .spawn(move || {
                 let tag = CStr::from_bytes_with_nul(b"RustStdoutStderr\0").unwrap();
                 let mut reader = BufReader::new(file);
@@ -960,7 +960,7 @@ pub unsafe extern "C" fn _rust_glue_entry(native_app: *mut ffi::android_app) {
         unsafe {
             // Name thread - this needs to happen here after attaching to a JVM thread,
             // since that changes the thread name to something like "Thread-2".
-            let thread_name = CStr::from_bytes_with_nul(b"android-main\0").unwrap();
+            let thread_name = CStr::from_bytes_with_nul(b"android_main\0").unwrap();
             libc::pthread_setname_np(libc::pthread_self(), thread_name.as_ptr());
 
             let app = AndroidApp::from_ptr(NonNull::new(native_app).unwrap(), jvm.clone());

--- a/android-activity/src/game_activity/mod.rs
+++ b/android-activity/src/game_activity/mod.rs
@@ -927,7 +927,7 @@ pub unsafe extern "C" fn _rust_glue_entry(native_app: *mut ffi::android_app) {
         unsafe {
             // Name thread - this needs to happen here after attaching to a JVM thread,
             // since that changes the thread name to something like "Thread-2".
-            let thread_name = CStr::from_bytes_with_nul(b"android_main\0").unwrap();
+            let thread_name = std::ffi::CStr::from_bytes_with_nul(b"android_main\0").unwrap();
             libc::pthread_setname_np(libc::pthread_self(), thread_name.as_ptr());
 
             let app = AndroidApp::from_ptr(NonNull::new(native_app).unwrap(), jvm.clone());

--- a/android-activity/src/native_activity/glue.rs
+++ b/android-activity/src/native_activity/glue.rs
@@ -870,7 +870,7 @@ extern "C" fn ANativeActivity_onCreate(
             unsafe {
                 // Name thread - this needs to happen here after attaching to a JVM thread,
                 // since that changes the thread name to something like "Thread-2".
-                let thread_name = CStr::from_bytes_with_nul(b"android_main\0").unwrap();
+                let thread_name = std::ffi::CStr::from_bytes_with_nul(b"android_main\0").unwrap();
                 libc::pthread_setname_np(libc::pthread_self(), thread_name.as_ptr());
 
                 // We want to specifically catch any panic from the application's android_main

--- a/android-activity/src/native_activity/glue.rs
+++ b/android-activity/src/native_activity/glue.rs
@@ -846,7 +846,7 @@ extern "C" fn ANativeActivity_onCreate(
         };
 
         std::thread::Builder::new()
-            .name("android-stdio".to_string())
+            .name("stdio-to-logcat".to_string())
             .spawn(move || {
                 let tag = CStr::from_bytes_with_nul(b"RustStdoutStderr\0").unwrap();
                 let mut reader = BufReader::new(file);
@@ -904,7 +904,7 @@ extern "C" fn ANativeActivity_onCreate(
             unsafe {
                 // Name thread - this needs to happen here after attaching to a JVM thread,
                 // since that changes the thread name to something like "Thread-2".
-                let thread_name = CStr::from_bytes_with_nul(b"android-main\0").unwrap();
+                let thread_name = CStr::from_bytes_with_nul(b"android_main\0").unwrap();
                 libc::pthread_setname_np(libc::pthread_self(), thread_name.as_ptr());
 
                 // We want to specifically catch any panic from the application's android_main


### PR DESCRIPTION
Name spawned threads to make things more clear during debugging and profiling.

[Max thread name is 15](https://stackoverflow.com/questions/5026531/thread-name-longer-than-15-chars), so we can't fit more descriptive names like `android-activity-main` (but open for some other naming scheme).