### PR TITLE
Upgrade to `ndk-sys 0.6.0` and `ndk 0.9.0`

### DIFF
--- a/android-activity/Cargo.toml
+++ b/android-activity/Cargo.toml
@@ -33,8 +33,8 @@ log = "0.4"
 jni-sys = "0.3"
 cesu8 = "1"
 jni = "0.21"
-ndk-sys = "0.5.0"
-ndk = { version = "0.8.0", default-features = false }
+ndk-sys = "0.6.0"
+ndk = { version = "0.9.0", default-features = false }
 ndk-context = "0.1"
 android-properties = "0.2"
 num_enum = "0.7"

--- a/android-activity/src/native_activity/input.rs
+++ b/android-activity/src/native_activity/input.rs
@@ -262,13 +262,8 @@ impl<'a> PointerImpl<'a> {
     #[inline]
     pub fn axis_value(&self, axis: Axis) -> f32 {
         let value: u32 = axis.into();
-        if let Ok(ndk_axis) = value.try_into() {
-            self.ndk_pointer.axis_value(ndk_axis)
-        } else {
-            // FIXME: We should also be able to query `Axis::__Unknown(u32)` values
-            // that can't currently be queried via the `ndk` `Pointer` API
-            0.0f32
-        }
+        let value = value as i32;
+        self.ndk_pointer.axis_value(value.into())
     }
 
     #[inline]
@@ -283,7 +278,8 @@ impl<'a> PointerImpl<'a> {
 
     #[inline]
     pub fn tool_type(&self) -> ToolType {
-        let value: u32 = self.ndk_pointer.tool_type().into();
+        let value: i32 = self.ndk_pointer.tool_type().into();
+        let value = value as u32;
         value.into()
     }
 }

--- a/android-activity/src/native_activity/mod.rs
+++ b/android-activity/src/native_activity/mod.rs
@@ -507,6 +507,7 @@ impl<'a> InputIteratorInner<'a> {
                     ndk::event::InputEvent::KeyEvent(e) => {
                         input::InputEvent::KeyEvent(input::KeyEvent::new(e))
                     }
+                    _ => todo!("NDK added a new type"),
                 };
 
                 // `finish_event` needs to be called for each event otherwise

--- a/examples/agdk-mainloop/Cargo.toml
+++ b/examples/agdk-mainloop/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 log = "0.4"
 android_logger = "0.11.0"
 android-activity = { path="../../android-activity", features = ["game-activity"] }
-ndk-sys = "0.5.0"
-ndk = "0.8.0"
+ndk-sys = "0.6.0"
+ndk = "0.9.0"
 
 [lib]
 name="main"

--- a/examples/na-mainloop/Cargo.toml
+++ b/examples/na-mainloop/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 log = "0.4"
 android_logger = "0.11.0"
 android-activity = { path="../../android-activity", features = [ "native-activity" ] }
-ndk-sys = "0.5.0"
-ndk = "0.8.0"
+ndk-sys = "0.6.0"
+ndk = "0.9.0"
 
 [lib]
 #name="na_mainloop"


### PR DESCRIPTION
The next breaking `ndk` release puts a lot of emphasis in improving `enum`s to finally be marked `non_exhaustive`, and carry possible future values in `__Unknown(i32)` variants.  This removes the lossy conversions that previously required `android-activity` to redefine its types, which could all be removed again.

The `repr()` types have also been updated, as `enum` constants in C are translated to `u32` by default in `bindgen` even though they're commonly passed as `int` to every API function that consumes them.
