### PR TITLE
Bump MSRV to 1.69.0 considering we can't build cargo ndk with 1.68

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         # See top README for MSRV policy
-        rust-version: [1.68.0, stable]
+        rust-version: [1.69.0, stable]
     steps:
       - uses: actions/checkout@v4
 

--- a/android-activity/CHANGELOG.md
+++ b/android-activity/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- rust-version bumped to 1.69.0 ([#156](https://github.com/rust-mobile/android-activity/pull/156))
 
 
 ## [0.5.2] - 2024-01-30

--- a/android-activity/Cargo.toml
+++ b/android-activity/Cargo.toml
@@ -10,12 +10,12 @@ documentation = "https://docs.rs/android-activity"
 description = "Glue for building Rust applications on Android with NativeActivity or GameActivity"
 license = "MIT OR Apache-2.0"
 
-# 1.68 was when Rust last updated the Android NDK version used to build the
+# 1.69 was when Rust last updated the Android NDK version used to build the
 # standard library which avoids needing the -lunwind workaround in build tools.
 #
 # We depend on cargo-ndk for building which has dropped support for the above
 # linker workaround.
-rust-version = "1.68.0"
+rust-version = "1.69.0"
 
 [features]
 # Note: we don't enable any backend by default since features


### PR DESCRIPTION
cargo ndk will fail to build with 1.68 due to a toml_edit dep.

Technically android-activity itself should still build with 1.68 but it's simpler to synchronize the `rust-version` with the minimum version that we actually test in CI (where we need to build cargo ndk)