### PR TITLE
Add a way to easily convert an AndroidAppWaker into a Waker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+Cargo.lock

--- a/android-activity/src/game_activity/mod.rs
+++ b/android-activity/src/game_activity/mod.rs
@@ -8,6 +8,7 @@ use std::ptr;
 use std::ptr::NonNull;
 use std::sync::Weak;
 use std::sync::{Arc, Mutex, RwLock};
+use std::task::{RawWaker, RawWakerVTable, Waker};
 use std::time::Duration;
 
 use libc::c_void;
@@ -117,6 +118,27 @@ impl AndroidAppWaker {
         unsafe {
             ALooper_wake(self.looper.as_ptr());
         }
+    }
+
+    /// Creates a [`Waker`] that wakes up the [`AndroidApp`].
+    ///
+    /// This is useful for using this crate in `async` environments.
+    ///
+    /// [`Waker`]: std::task::Waker
+    pub fn waker(self) -> Waker {
+        const VTABLE: RawWakerVTable = RawWakerVTable::new(clone, wake, wake, drop);
+
+        unsafe fn clone(data: *const ()) -> RawWaker {
+            RawWaker::new(data, &VTABLE)
+        }
+
+        unsafe fn wake(data: *const ()) {
+            ndk_sys::ALooper_wake(data as *const _ as *mut _)
+        }
+
+        unsafe fn drop(_: *const ()) {}
+
+        unsafe { Waker::from_raw(RawWaker::new(self.looper.as_ptr() as *const (), &VTABLE)) }
     }
 }
 


### PR DESCRIPTION
This commit adds a "waker()" method to AndroidAppWaker. It converts it
into an `std::task::Waker`, which is the type of waker used by
asynchronous tasks for scheduling. The goal is to allow AndroidAppWaker
to be easily used to set up an asynchronous context.

The implementation is very efficient, owing to the "static pointer"
style of coding already used. The "wake" function just calls
ALooper_wake, and cloning/dropping the waker is just a copy.

Discussion questions:

- Should `waker()` take `&self` or `self`? I chose the latter.

