### PR TITLE
Fix GameActivity touch inputs in the presence of a stylus

### DIFF
--- a/android-activity/game-activity-csrc/game-activity/native_app_glue/android_native_app_glue.c
+++ b/android-activity/game-activity-csrc/game-activity/native_app_glue/android_native_app_glue.c
@@ -29,11 +29,11 @@
 #define NATIVE_APP_GLUE_KEY_EVENTS_DEFAULT_BUF_SIZE 4
 
 #define LOGI(...) \
-    ((void)__android_log_print(ANDROID_LOG_INFO, "threaded_app", __VA_ARGS__))
+    ((void)__android_log_print(ANDROID_LOG_INFO, "android_activity", __VA_ARGS__))
 #define LOGE(...) \
-    ((void)__android_log_print(ANDROID_LOG_ERROR, "threaded_app", __VA_ARGS__))
+    ((void)__android_log_print(ANDROID_LOG_ERROR, "android_activity", __VA_ARGS__))
 #define LOGW(...) \
-    ((void)__android_log_print(ANDROID_LOG_WARN, "threaded_app", __VA_ARGS__))
+    ((void)__android_log_print(ANDROID_LOG_WARN, "android_activity", __VA_ARGS__))
 #define LOGW_ONCE(...)                                        \
     do {                                                       \
         static bool alogw_once##__FILE__##__LINE__##__ = true; \
@@ -46,7 +46,7 @@
 /* For debug builds, always enable the debug traces in this library */
 #ifndef NDEBUG
 #define LOGV(...)                                                   \
-    ((void)__android_log_print(ANDROID_LOG_VERBOSE, "threaded_app", \
+    ((void)__android_log_print(ANDROID_LOG_VERBOSE, "android_activity", \
                                __VA_ARGS__))
 #else
 #define LOGV(...) ((void)0)

--- a/android-activity/game-activity-csrc/game-activity/native_app_glue/android_native_app_glue.c
+++ b/android-activity/game-activity-csrc/game-activity/native_app_glue/android_native_app_glue.c
@@ -264,7 +264,7 @@ static bool default_key_filter(const GameActivityKeyEvent* event) {
 
 static bool default_motion_filter(const GameActivityMotionEvent* event) {
     // Ignore any non-touch events.
-    return event->source == SOURCE_TOUCHSCREEN;
+    return event->source & SOURCE_TOUCHSCREEN;
 }
 
 // --------------------------------------------------------------------


### PR DESCRIPTION
I noticed touch inputs weren't working on my Galaxy S9 tab device which
includes a stylus. The value was 0xD002 for source, which seems to be:

```
SOURCE_CLASS_POINTER     0b0000 0000 0000 0010
SOURCE_STYLUS            0b0100 0000 0000 0000
SOURCE_BLUETOOTH_STYLUS  0b1000 0000 0000 0000
SOURCE_TOUCHSCREEN       0b0001 0000 0000 0000
----------------------------------------------
                0xD002 = 0b1101 0000 0000 0010
```

Let's modify default_motion_filter to use bitwise AND (&) instead of
equality (==) when checking SOURCE_TOUCHSCREEN. This ensures stylus
inputs (which combine touchscreen and stylus flags) are not discarded,
while still filtering non-touch events.