### PR TITLE
Bump rust-version to 1.73.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         # See top README for MSRV policy
-        rust-version: [1.69.0, stable]
+        rust-version: [1.73.0, stable]
     steps:
       - uses: actions/checkout@v4
 

--- a/android-activity/CHANGELOG.md
+++ b/android-activity/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   > - `Source::is_xxx_class()` functions are replaced by querying `Source::class()` and comparing against variants from the returned `SourceClass` `bitflags` enum.
   > - `SourceFlags::TRACKBALL` (from `Source::is_trackball_class()`) is named `SourceClass::NAVIGATION` in the `ndk`.
 
+- rust-version bumped to 1.73.0 ([#193](https://github.com/rust-mobile/android-activity/pull/193))
+
 ## [0.6.0] - 2024-04-26
 
 ### Changed

--- a/android-activity/Cargo.toml
+++ b/android-activity/Cargo.toml
@@ -10,12 +10,10 @@ documentation = "https://docs.rs/android-activity"
 description = "Glue for building Rust applications on Android with NativeActivity or GameActivity"
 license = "MIT OR Apache-2.0"
 
-# 1.69 was when Rust last updated the Android NDK version used to build the
-# standard library which avoids needing the -lunwind workaround in build tools.
-#
-# We depend on cargo-ndk for building which has dropped support for the above
-# linker workaround.
-rust-version = "1.69.0"
+# Even though we could technically still build with 1.69, 1.73 has a fix for the
+# definition of the `stat` struct on Android, and so it seems worthwhile drawing
+# a line under that to ensure android-activity applications have that fix.
+rust-version = "1.73.0"
 
 [features]
 # Note: we don't enable any backend by default since features

--- a/android-activity/generate-bindings.sh
+++ b/android-activity/generate-bindings.sh
@@ -14,6 +14,7 @@ while read ARCH && read TARGET ; do
 
     # --module-raw-line 'use '
     bindgen game-activity-ffi.h -o src/game_activity/ffi_$ARCH.rs \
+        --rust-target '1.73.0' \
         --blocklist-item 'JNI\w+' \
         --blocklist-item 'C?_?JNIEnv' \
         --blocklist-item '_?JavaVM' \


### PR DESCRIPTION
bindgen-cli 0.71 (which we want to use) requires rustc >= 1.70

If we're bumping the rust version anyway it looks like it makes sense to at least bump to 1.73 which happens to fix the `stat` struct definition for Android.

Technically since we run bindgen-cli offline, their minimum version doesn't _need_ to affect us but I'd rather just sync and not track multiple "minimum" versions for this crate.

Rust 1.73 was released October 2023, which is still well over a year old and very conservative.

This updates `generate-bindings.sh` to pass `--rust-target 1.73.0` so we avoid generating bindings that require a more recent compiler.