### PR TITLE
Re-export 'ndk' and 'ndk_sys' crates

### DIFF
--- a/android-activity/CHANGELOG.md
+++ b/android-activity/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   > - `SourceFlags::TRACKBALL` (from `Source::is_trackball_class()`) is named `SourceClass::NAVIGATION` in the `ndk`.
 
 - rust-version bumped to 1.73.0 ([#193](https://github.com/rust-mobile/android-activity/pull/193))
+- The `ndk` and `ndk-sys` crates are now re-exported under `android_activity::ndk` and `android_activity::ndk_sys` ([#194](https://github.com/rust-mobile/android-activity/pull/194))
 
 ## [0.6.0] - 2024-04-26
 

--- a/android-activity/src/lib.rs
+++ b/android-activity/src/lib.rs
@@ -119,12 +119,17 @@ use std::sync::Arc;
 use std::sync::RwLock;
 use std::time::Duration;
 
-use input::KeyCharacterMap;
+use bitflags::bitflags;
 use libc::c_void;
+
 use ndk::asset::AssetManager;
 use ndk::native_window::NativeWindow;
 
-use bitflags::bitflags;
+// Since we expose `ndk` types in our public API it's convenient if crates can
+// defer to these re-exported APIs and avoid having to bump explicit
+// dependencies when they pull in new releases of android-activity.
+pub use ndk;
+pub use ndk_sys;
 
 #[cfg(not(target_os = "android"))]
 compile_error!("android-activity only supports compiling for Android");
@@ -162,6 +167,7 @@ pub mod error;
 use error::Result;
 
 pub mod input;
+use input::KeyCharacterMap;
 
 mod config;
 pub use config::ConfigurationRef;


### PR DESCRIPTION
Since we expose `ndk` types in the public API it makes sense to re-export these APIs so users of android-activity can defer to these without needing to manually sync the versions for explicit dependencies.
